### PR TITLE
Set a background to make example config valid

### DIFF
--- a/TerminalDocs/customize-settings/color-schemes.md
+++ b/TerminalDocs/customize-settings/color-schemes.md
@@ -20,7 +20,7 @@ Color schemes can be defined in the `schemes` array of your settings.json file. 
     "name" : "Campbell",
 
     "cursorColor": "#FFFFFF",
-    "selectionBackground": "#",
+    "selectionBackground": "#FFFFFF",
 
     "background" : "#0C0C0C",
     "foreground" : "#CCCCCC",


### PR DESCRIPTION
 The example config contains an invalid color for selectionBackground which results in a parse error when pasting it into settings.json. To fix it, we can just fill it with 'white'.