### PR TITLE
add hyphen to command line

### DIFF
--- a/TerminalDocs/cascadia-code.md
+++ b/TerminalDocs/cascadia-code.md
@@ -10,7 +10,7 @@ ms.service: terminal
 
 # Cascadia Code
 
-Cascadia Code is a new monospaced font from Microsoft that provides a fresh experience for command line applications and text editors. Cascadia Code was developed alongside Windows Terminal. This font is most recommended to be used with terminal applications and text editors such as Visual Studio and Visual Studio Code.
+Cascadia Code is a new monospaced font from Microsoft that provides a fresh experience for command-line applications and text editors. Cascadia Code was developed alongside Windows Terminal. This font is most recommended to be used with terminal applications and text editors such as Visual Studio and Visual Studio Code.
 
 ## Cascadia Code versions
 
@@ -25,7 +25,7 @@ There are multiple versions of Cascadia Code available that include ligatures an
 
 ## Powerline and programming ligatures
 
-Powerline is a common command line plugin that allows you to display additional information in your prompt. It uses a few additional glyphs to display this information properly. To learn more about setting up Powerline in your command prompt, visit the [Powerline in Windows Terminal](./tutorials/powerline-setup.md) page.
+Powerline is a common command-line plugin that allows you to display additional information in your prompt. It uses a few additional glyphs to display this information properly. To learn more about setting up Powerline in your command prompt, visit the [Powerline in Windows Terminal](./tutorials/powerline-setup.md) page.
 
 Programming ligatures are glyphs that are created by combining characters. They are most useful when writing code. The "Code" variants include ligatures, whereas the "Mono" variants exclude them.
 

--- a/TerminalDocs/command-line-arguments.md
+++ b/TerminalDocs/command-line-arguments.md
@@ -1,6 +1,6 @@
 ---
-title: Windows Terminal Command Line Arguments
-description: Learn how to create command line arguments for Windows Terminal.
+title: Windows Terminal command-line arguments
+description: Learn how to create command-line arguments for Windows Terminal.
 author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 05/19/2020
@@ -8,14 +8,14 @@ ms.topic: how-to
 ms.service: terminal
 ---
 
-# Using command line arguments for Windows Terminal
+# Using command-line arguments for Windows Terminal
 
 You can use `wt.exe` to open a new instance of Windows Terminal from the command line. You can also use the execution alias `wt` instead.
 
 > [!NOTE]
 > If you built Windows Terminal from the source code on [GitHub](https://github.com/microsoft/terminal), you can open that build using `wtd.exe` or `wtd`.
 
-![Windows Terminal command line argument for split panes](./images/terminal-command-args.gif)
+![Windows Terminal command-line argument for split panes](./images/terminal-command-args.gif)
 
 ## Command line syntax
 
@@ -25,7 +25,7 @@ The `wt` command line accepts two types of values: **options** and **commands**.
 wt [options] [command ; ]
 ```
 
-To display a help message listing the available command line arguments, enter: `wt -h`, `wt --help`, `wt -?`, or `wt /?`.
+To display a help message listing the available command-line arguments, enter: `wt -h`, `wt --help`, `wt -?`, or `wt /?`.
 
 ## Options and commands
 
@@ -120,7 +120,7 @@ wt ; ;
 wt `; `;
 ```
 
-PowerShell uses a semicolon ; to delimit statements. To interpret a semicolon ; as a command delimiter for wt command line arguments, you need to escape semicolon characters using backticks. PowerShell also has the stop parsing operator (--%), which instructs it to stop interpreting anything after it and just pass it on verbatim.
+PowerShell uses a semicolon ; to delimit statements. To interpret a semicolon ; as a command delimiter for wt command-line arguments, you need to escape semicolon characters using backticks. PowerShell also has the stop parsing operator (--%), which instructs it to stop interpreting anything after it and just pass it on verbatim.
 
 #### [Linux](#tab/linux)
 
@@ -148,7 +148,7 @@ wt -p "Command Prompt" ; new-tab -p "Windows PowerShell"
 wt -p "Command Prompt" `; new-tab -p "Windows PowerShell"
 ```
 
-PowerShell uses a semicolon ; to delimit statements. To interpret a semicolon ; as a command delimiter for wt command line arguments, you need to escape semicolon characters using backticks. PowerShell also has the stop parsing operator (--%), which instructs it to stop interpreting anything after it and just pass it on verbatim.
+PowerShell uses a semicolon ; to delimit statements. To interpret a semicolon ; as a command delimiter for wt command-line arguments, you need to escape semicolon characters using backticks. PowerShell also has the stop parsing operator (--%), which instructs it to stop interpreting anything after it and just pass it on verbatim.
 
 #### [Linux](#tab/linux)
 
@@ -178,7 +178,7 @@ wt -p "Command Prompt" ; split-pane -p "Windows PowerShell" ; split-pane -H wsl.
 wt -p "Command Prompt" `; split-pane -p "Windows PowerShell" `; split-pane -H wsl.exe
 ```
 
-PowerShell uses a semicolon ; to delimit statements. To interpret a semicolon ; as a command delimiter for wt command line arguments, you need to escape semicolon characters using backticks. PowerShell also has the stop parsing operator (--%), which instructs it to stop interpreting anything after it and just pass it on verbatim.
+PowerShell uses a semicolon ; to delimit statements. To interpret a semicolon ; as a command delimiter for wt command-line arguments, you need to escape semicolon characters using backticks. PowerShell also has the stop parsing operator (--%), which instructs it to stop interpreting anything after it and just pass it on verbatim.
 
 #### [Linux](#tab/linux)
 
@@ -263,6 +263,6 @@ wt new-tab "cmd" `; split-pane -p "Windows PowerShell" `; split-pane -H wsl.exe
 wt --% new-tab cmd ; split-pane -p "Windows PowerShell" ; split-pane -H wsl.exe
 ```
 
-In both of these examples, the newly created Windows Terminal window will create the window by correctly parsing all the provided command line arguments.
+In both of these examples, the newly created Windows Terminal window will create the window by correctly parsing all the provided command-line arguments.
 
 However, these methods are _not_ recommended currently, as PowerShell will wait for the newly-created terminal window to be closed before returning control to PowerShell. By default, PowerShell will always wait for Windows Store applications (like Windows Terminal) to close before returning to the prompt. Note that this is different than the behavior of Command Prompt, which will return to the prompt immediately.

--- a/TerminalDocs/customize-settings/color-schemes.md
+++ b/TerminalDocs/customize-settings/color-schemes.md
@@ -52,7 +52,7 @@ ___
 
 ## Included color schemes
 
-Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button. If you would like to set up a color scheme inside one of your command line profiles, add the `colorScheme` property with the color scheme's `name` as the value.
+Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button. If you would like to set up a color scheme inside one of your command-line profiles, add the `colorScheme` property with the color scheme's `name` as the value.
 
 ```json
 "colorScheme": "COLOR SCHEME NAME"

--- a/TerminalDocs/get-started.md
+++ b/TerminalDocs/get-started.md
@@ -43,7 +43,7 @@ The terminal supports customization of [global properties](./customize-settings/
 
 ## Command line arguments
 
-You can launch the terminal in a specific configuration using command line arguments. These arguments let you open the terminal with specific tabs and panes with custom profile settings. Learn more about command line arguments on the [Command line arguments page](./command-line-arguments.md).
+You can launch the terminal in a specific configuration using command-line arguments. These arguments let you open the terminal with specific tabs and panes with custom profile settings. Learn more about command-line arguments on the [Command line arguments page](./command-line-arguments.md).
 
 ## Troubleshooting
 

--- a/TerminalDocs/index.md
+++ b/TerminalDocs/index.md
@@ -11,16 +11,16 @@ ms.localizationpriority: high
 
 # What is Windows Terminal?
 
-Windows Terminal is a modern terminal application for users of command line tools and shells like Command Prompt, PowerShell, and Windows Subsystem for Linux (WSL). Its main features include multiple tabs, panes, Unicode and UTF-8 character support, a GPU accelerated text rendering engine, and the ability to create your own themes and customize text, colors, backgrounds, and shortcut key bindings.
+Windows Terminal is a modern terminal application for users of command-line tools and shells like Command Prompt, PowerShell, and Windows Subsystem for Linux (WSL). Its main features include multiple tabs, panes, Unicode and UTF-8 character support, a GPU accelerated text rendering engine, and the ability to create your own themes and customize text, colors, backgrounds, and shortcut key bindings.
 
 ![Windows Terminal screenshot](./images/overview.png)
 
 > [!NOTE]
 > [What's the difference between a console, a terminal, and a shell?](https://www.hanselman.com/blog/WhatsTheDifferenceBetweenAConsoleATerminalAndAShell.aspx) Read Scott Hanselman's explanation.
 
-## Multiple profiles supporting a variety of command line applications
+## Multiple profiles supporting a variety of command-line applications
 
-Any application that has a command line interface can be run inside Windows Terminal. This includes everything from PowerShell and Command Prompt to Azure Cloud Shell and any WSL distribution such as Ubuntu or Oh-My-Zsh.
+Any application that has a command-line interface can be run inside Windows Terminal. This includes everything from PowerShell and Command Prompt to Azure Cloud Shell and any WSL distribution such as Ubuntu or Oh-My-Zsh.
 
 ## Customized schemes and configurations
 
@@ -40,7 +40,7 @@ Windows Terminal can display Unicode and UTF-8 characters such as emoji and char
 
 ## GPU accelerated text rendering
 
-Windows Terminal uses the GPU to render its text, thus providing improved performance over the default Windows command line experience.
+Windows Terminal uses the GPU to render its text, thus providing improved performance over the default Windows command-line experience.
 
 ## Background image support
 
@@ -48,7 +48,7 @@ You can have background images and gifs inside your Windows Terminal window. Inf
 
 ## Command line arguments
 
-You can set Windows Terminal to launch in a specific configuration using command line arguments. You can specify which profile to open in a new tab, which folder directory should be selected, open the terminal with split window panes, and choose which tab should be in focus.
+You can set Windows Terminal to launch in a specific configuration using command-line arguments. You can specify which profile to open in a new tab, which folder directory should be selected, open the terminal with split window panes, and choose which tab should be in focus.
 
 For example, to open Windows Terminal from PowerShell with three panes, with the left pane running a Command Prompt profile and the right pane split between your PowerShell and your default profile running WSL, enter:
 
@@ -56,4 +56,4 @@ For example, to open Windows Terminal from PowerShell with three panes, with the
 wt -p "Command Prompt" `; split-pane -p "Windows PowerShell" `; split-pane -H wsl.exe
 ```
 
-Learn how to set up command line arguments on the [Command line arguments page](./command-line-arguments.md).
+Learn how to set up command-line arguments on the [Command line arguments page](./command-line-arguments.md).

--- a/TerminalDocs/panes.md
+++ b/TerminalDocs/panes.md
@@ -10,7 +10,7 @@ ms.service: terminal
 
 # Panes in Windows Terminal
 
-Panes give you the ability to run multiple command line applications next to each other within the same tab. This minimizes the need to switch between tabs and lets you see multiple prompts at once.
+Panes give you the ability to run multiple command-line applications next to each other within the same tab. This minimizes the need to switch between tabs and lets you see multiple prompts at once.
 
 ## Creating a new pane
 

--- a/TerminalDocs/troubleshooting.md
+++ b/TerminalDocs/troubleshooting.md
@@ -39,11 +39,11 @@ To have the shell automatically set your tab title, [visit the set the tab title
 
 ## Command line arguments in PowerShell
 
-Visit the [Command line arguments page](./command-line-arguments.md) to learn how command line arguments operate in PowerShell.
+Visit the [Command line arguments page](./command-line-arguments.md) to learn how command-line arguments operate in PowerShell.
 
 ## Command line arguments in WSL
 
-Visit the [Command line arguments page](./command-line-arguments.md) to learn how command line arguments operate in WSL.
+Visit the [Command line arguments page](./command-line-arguments.md) to learn how command-line arguments operate in WSL.
 
 ## Problem setting `startingDirectory`
 


### PR DESCRIPTION
Command line should be hyphened when used as an adjective:
https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/c/command-line