### PR TITLE
Fix error wrt splitting panes

### DIFF
--- a/TerminalDocs/customize-settings/key-bindings.md
+++ b/TerminalDocs/customize-settings/key-bindings.md
@@ -361,7 +361,7 @@ This halves the size of the active pane and opens another. Without any arguments
 
 | Name | Necessity | Accepts | Description |
 | ---- | --------- | ------- | ----------- |
-| `split` | Required | `"vertical"`, `"horizontal"`, `"auto"` | How the pane will split. `"auto"` will split in the direction that provides the most surface area. |
+| `split` | Required | `"vertical"`, `"horizontal"`, `"auto"` | How the pane will split. `"auto"` will split in the direction that provides the squarest panes. |
 | `commandLine` | Optional | Executable file name as a string | Executable run within the pane. |
 | `startingDirectory` | Optional | Folder location as a string | Directory in which the pane will open. |
 | `tabTitle` | Optional | String | Title of the tab when the new pane is focused. |

--- a/TerminalDocs/panes.md
+++ b/TerminalDocs/panes.md
@@ -19,7 +19,7 @@ You can either create a new vertical or horizontal pane in Windows Terminal. Spl
 ![Windows Terminal create pane](./images/open-panes.gif)
 _Configuration: [Raspberry Ubuntu](./custom-terminal-gallery/raspberry-ubuntu.md)_
 
-If you would like to change these key bindings, you can create new ones using the `splitPane` action and `vertical` or `horizontal` values for the `split` property in your profiles.json file. If you just want a pane with the maximum amount of surface area, you can set `split` to `auto`. To learn more about key bindings, visit the [key bindings page](./customize-settings/key-bindings.md).
+If you would like to change these key bindings, you can create new ones using the `splitPane` action and `vertical`, `horizontal`, or `auto` values for the `split` property in your profiles.json file. The `auto` method will choose the direction that gives you the squarest panes. To learn more about key bindings, visit the [key bindings page](./customize-settings/key-bindings.md).
 
 ```json
 { "command": { "action": "splitPane", "split": "vertical" }, "keys": "alt+shift+plus" },


### PR DESCRIPTION
Splitting panes always provides panes of the same surface area regardless of direction.

The best geometric description I thought of was "splits along the shorter perpendicular bisector", which is quite precise, but probably a bit too technical for these docs. Apparently "squarest" is a word, though, and it matches intuition if you see the split in action.

I also tried to simplify the description of `auto` and `splitPane`. The latter now has all the values next to each other in one list. If someone were skimming (something I do a lot) the could miss the `auto` value with current wording.

Supersedes https://github.com/microsoft/terminal/pull/5951