### PR TITLE
Add settings for paste warnings

### DIFF
--- a/TerminalDocs/customize-settings/global-settings.md
+++ b/TerminalDocs/customize-settings/global-settings.md
@@ -299,6 +299,48 @@ This determines the word delimiters used in a double-click selection. Word delim
 
 ___
 
+## Paste warnings
+
+### Warn when the text to paste is very large
+
+When this is set to `true`, trying to paste text with more than 5 KiB of characters will display a dialog asking you whether to continue or not with the paste. When it's set to `false`, the dialog is not shown and instead the text is pasted right away. If you often right-click on the terminal by accident after having selected a lot of text, this might be useful to prevent the terminal from becoming unresponsive while the program connected to the terminal receives the clipboard's content.
+
+**Property name:** `largePasteWarning`
+
+**Necessity:** Optional
+
+**Accepts:** `true`, `false`
+
+**Default value:** `true`
+
+### Warn when the text to paste contains multiple lines
+
+When this is set to `true`, trying to paste text with multiple lines will display a dialog asking you whether to continue or not with the paste. When it's set to `false`, the dialog is not shown and instead the text is pasted right away. In most shells, one line corresponds to one command so if you paste text that contains the "new line" character into a shell, one or more command(s) might be executed automatically upon paste, without you having time to validate the commands. This can be useful if you often copy and paste commands from untrusted websites.
+
+**Property name:** `multiLinePasteWarning`
+
+**Necessity:** Optional
+
+**Accepts:** `true`, `false`
+
+**Default value:** `true`
+
+### Word delimiters
+
+This determines the word delimiters used in a double-click selection. Word delimiters are characters that specify where the boundary is between two words. The most common examples are spaces, semicolons, commas, and periods.
+
+**Property name:** `wordDelimiters`
+
+**Necessity:** Optional
+
+**Accepts:** Characters as a string
+
+**Default value:** <code>&nbsp;&#x2f;&#x5c;&#x28;&#x29;&#x22;&#x27;&#x2d;&#x3a;&#x2c;&#x2e;&#x3b;&#x3c;&#x3e;&#x7e;&#x21;&#x40;&#x23;&#x24;&#x25;&#x5e;&#x26;&#x2a;&#x7c;&#x2b;&#x3d;&#x5b;&#x5d;&#x7b;&#x7d;&#x7e;&#x3f;│</code><br>_(`│` is `U+2502 BOX DRAWINGS LIGHT VERTICAL`)_
+
+<br />
+
+___
+
 ## Scroll speed
 
 This is the number of rows to scroll at a time with the mouse wheel. This will override the system setting if the value is not zero or `"system"`.

--- a/TerminalDocs/customize-settings/global-settings.md
+++ b/TerminalDocs/customize-settings/global-settings.md
@@ -325,18 +325,6 @@ When this is set to `true`, trying to paste text with multiple lines will displa
 
 **Default value:** `true`
 
-### Word delimiters
-
-This determines the word delimiters used in a double-click selection. Word delimiters are characters that specify where the boundary is between two words. The most common examples are spaces, semicolons, commas, and periods.
-
-**Property name:** `wordDelimiters`
-
-**Necessity:** Optional
-
-**Accepts:** Characters as a string
-
-**Default value:** <code>&nbsp;&#x2f;&#x5c;&#x28;&#x29;&#x22;&#x27;&#x2d;&#x3a;&#x2c;&#x2e;&#x3b;&#x3c;&#x3e;&#x7e;&#x21;&#x40;&#x23;&#x24;&#x25;&#x5e;&#x26;&#x2a;&#x7c;&#x2b;&#x3d;&#x5b;&#x5d;&#x7b;&#x7d;&#x7e;&#x3f;│</code><br>_(`│` is `U+2502 BOX DRAWINGS LIGHT VERTICAL`)_
-
 <br />
 
 ___


### PR DESCRIPTION
I added a new section called _Paste warnings_ with the new settings
from this PR: https://github.com/microsoft/terminal/pull/6631.
I also added a little bit of explanation about you would want these
warnings to be enabled.

**DO NOT MERGE FOR NOW because the corresponding PR on the
Windows Terminal repository is not merged yet.**