### PR TITLE
Remove tabSwitcher docs from master

### DIFF
--- a/TerminalDocs/customize-settings/global-settings.md
+++ b/TerminalDocs/customize-settings/global-settings.md
@@ -136,30 +136,6 @@ When this is set to `true`, closing a window with multiple tabs open _will_ requ
 :::column-end:::
 :::row-end:::
 
-### Use Tab Switcher Experience
-
-:::row:::
-:::column span="":::
-When this is set to `true`, the `nextTab` and `prevTab` commands will use the Tab Switcher UI. The UI will show all the currently open tabs in a vertical list, navigable with the keyboard or mouse.
-The tab switcher will open on the initial press of the keybindings for `nextTab` and `prevTab`, and will stay open as long as a modifier key is held down. When all modifier keys are released, the switcher will close and the highlighted tab will be focused. <kbd>Tab</kbd>/<kbd>Shift+Tab</kbd>, the Up and Down arrow keys, and the `nextTab`/`prevTab` keybindings can be used to cycle through the switcher UI.
-
-**Property name:** `useTabSwitcher`
-
-**Necessity:** Optional
-
-**Accepts:** `true`, `false`
-
-**Default value:** `true`
-
-> [!IMPORTANT]
-> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview/).
-
-:::column-end:::
-:::column span="":::
-
-:::column-end:::
-:::row-end:::
-
 <br />
 
 ___

--- a/TerminalDocs/customize-settings/key-bindings.md
+++ b/TerminalDocs/customize-settings/key-bindings.md
@@ -321,24 +321,6 @@ This opens a specific tab depending on the index.
 | ---- | --------- | ------- | ----------- |
 | `index` | Required | Integer | Tab that will open based on its position in the tab bar (starting at 0). |
 
-
-### Tab Search ([Preview](https://aka.ms/terminal-preview/))
-
-This opens the tab search box.
-
-**Command name:** `tabSearch`
-
-**Default binding:**
-
-_This command is not currently bound in the default settings_.
-
-```json
-{"command": "tabSearch", "keys": "ctrl+shift+t"}
-```
-
-> [!IMPORTANT]
-> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview/).
-
 ### Rename tab ([Preview](https://aka.ms/terminal-preview/))
 
 This command can be used to rename a tab to a specific string.


### PR DESCRIPTION
I accidentally merged #107 into master, so I'm removing these docs to prevent merge conflicts with the release-1.3 branch. I've moved this content into the cinnamon/release-1.3 branch already.