### PR TITLE
Explicit state that windows key is not supported

### DIFF
--- a/TerminalDocs/customize-settings/key-bindings.md
+++ b/TerminalDocs/customize-settings/key-bindings.md
@@ -89,7 +89,8 @@ ___
 
 `ctrl+`, `shift+`, `alt+`
 
-> Note: the `Windows` key is not yet supported as a modifier. 
+> [!NOTE]
+> The `Windows` key is not supported as a modifier. 
 
 ### Modifier keys
 

--- a/TerminalDocs/customize-settings/key-bindings.md
+++ b/TerminalDocs/customize-settings/key-bindings.md
@@ -89,6 +89,8 @@ ___
 
 `ctrl+`, `shift+`, `alt+`
 
+> Note: the `Windows` key is not yet supported as a modifier. 
+
 ### Modifier keys
 
 | Type | Keys |


### PR DESCRIPTION
The documentation is not clear that the `Windows` key is not a valid modifier for key bindings. I think people are looking for this when they try to customize their terminal - at least I did and it took me a lot of effort to find that this is not ab option yet.

The corresponding Issue for the feature request is [#3184](https://github.com/microsoft/terminal/issues/3184)