### PR TITLE
Move 'plus' to symbols category

### DIFF
--- a/TerminalDocs/customize-settings/key-bindings.md
+++ b/TerminalDocs/customize-settings/key-bindings.md
@@ -97,8 +97,8 @@ ___
 | Type | Keys |
 | ---- | ---- |
 | Function and alphanumeric keys | `f1-f24`, `a-z`, `0-9` |
-| Symbols | ``` ` ```, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/` |
-| Arrow keys | `down`, `left`, `right`, `up`, `pagedown`, `pageup`, `pgdn`, `pgup`, `end`, `home`, `plus` |
+| Symbols | ``` ` ```, `plus`, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/` |
+| Arrow keys | `down`, `left`, `right`, `up`, `pagedown`, `pageup`, `pgdn`, `pgup`, `end`, `home` |
 | Action keys | `tab`, `enter`, `esc`, `escape`, `space`, `backspace`, `delete`, `insert`, `app`, `menu`  |
 | Numpad keys | `numpad_0-numpad_9`, `numpad0-numpad9`, `numpad_add`, `numpad_plus`, `numpad_decimal`, `numpad_period`, `numpad_divide`, `numpad_minus`, `numpad_subtract`, `numpad_multiply` |
 


### PR DESCRIPTION
Plus was under arrow keys. Moved it to symbols.