### PR TITLE
Add additional explanation to color schemes page

### DIFF
--- a/TerminalDocs/customize-settings/color-schemes.md
+++ b/TerminalDocs/customize-settings/color-schemes.md
@@ -50,6 +50,22 @@ Every setting, aside from `name`, accepts a color as a string in hex format: `"#
 
 ___
 
+## Adding a color scheme to a profile
+
+You can add a color scheme to a profile by adding the `colorScheme` property to the profile and setting it to the color scheme's name. Below is an example profile using the One Half Dark color scheme.
+
+```json
+{
+    "name" : "PowerShell",
+    "source": "Windows.Terminal.PowershellCore",
+    "colorScheme" : "One Half Dark"
+}
+```
+
+<br />
+
+___
+
 ## Included color schemes
 
 Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button. If you would like to set up a color scheme inside one of your command-line profiles, add the `colorScheme` property with the color scheme's `name` as the value.

--- a/TerminalDocs/customize-settings/color-schemes.md
+++ b/TerminalDocs/customize-settings/color-schemes.md
@@ -68,7 +68,7 @@ ___
 
 ## Included color schemes
 
-Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button.
+Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button. If you'd like to change the colors of a default scheme, you can copy the scheme's JSON out of the defaults.json file and place it in your `schemes` array inside your settings.json file. From there, you can change any colors you'd like.
 
 ### Campbell
 

--- a/TerminalDocs/customize-settings/color-schemes.md
+++ b/TerminalDocs/customize-settings/color-schemes.md
@@ -52,7 +52,7 @@ ___
 
 ## Adding a color scheme to a profile
 
-You can add a color scheme to a profile by adding the `colorScheme` property to the profile and setting it to the color scheme's name. Below is an example profile using the One Half Dark color scheme.
+If you would like to set up a color scheme inside one of your profiles, add the `colorScheme` property with the color scheme's `name` as the value. Below is an example of a profile using the One Half Dark color scheme.
 
 ```json
 {
@@ -68,11 +68,7 @@ ___
 
 ## Included color schemes
 
-Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button. If you would like to set up a color scheme inside one of your command-line profiles, add the `colorScheme` property with the color scheme's `name` as the value.
-
-```json
-"colorScheme": "COLOR SCHEME NAME"
-```
+Windows Terminal includes these color schemes inside the defaults.json file, which can be accessed by holding <kbd>alt</kbd> and selecting the settings button.
 
 ### Campbell
 


### PR DESCRIPTION
Add a "Adding a color scheme to a profile" section to the color schemes. This should help further explain how to add color scheme to a profile.

Closes #129 
Closes #130 