### PR TITLE
Update global-settings.md

### DIFF
--- a/TerminalDocs/customize-settings/global-settings.md
+++ b/TerminalDocs/customize-settings/global-settings.md
@@ -322,9 +322,11 @@ This determines the word delimiters used in a double-click selection. Word delim
 
 **Accepts:** Characters as a string
 
-**Default value:** <code>&nbsp;&#x2f;&#x5c;&#x28;&#x29;&#x22;&#x27;&#x2d;&#x3a;&#x2c;&#x2e;&#x3b;&#x3c;&#x3e;&#x7e;&#x21;&#x40;&#x23;&#x24;&#x25;&#x5e;&#x26;&#x2a;&#x7c;&#x2b;&#x3d;&#x5b;&#x5d;&#x7b;&#x7d;&#x7e;&#x3f;│</code><br>_(`│` is `U+2502 BOX DRAWINGS LIGHT VERTICAL`)_
+**Default value:** <code>&nbsp;&#x2f;&#x5c;&#x5c;&#x28;&#x29;&#x5c;&#x22;&#x27;&#x2d;&#x3a;&#x2c;&#x2e;&#x3b;&#x3c;&#x3e;&#x7e;&#x21;&#x40;&#x23;&#x24;&#x25;&#x5e;&#x26;&#x2a;&#x7c;&#x2b;&#x3d;&#x5b;&#x5d;&#x7b;&#x7d;&#x7e;&#x3f;│</code>
 
-<br />
+_(`│` is `U+2502 BOX DRAWINGS LIGHT VERTICAL`)_
+> [!IMPORTANT]
+> The following characters must be escaped with a backslash : `\`, `"`
 
 ___
 


### PR DESCRIPTION
The default value string of the wordDelimiters setting cannot be "as-is" cut-pasted in the JSON configuration file. Some characters must be escaped with the backslash.