### PR TITLE
Show how to support powerline glyphs in the VS Code terminal

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -89,6 +89,8 @@ Your Windows PowerShell profile settings.json file should now look like this:
     "hidden": false
 },
 ```
+> [!TIP]
+> If you want to support Powerline glyphs in the VS Code terminal, you can add `"terminal.integrated.fontFamily": "Cascadia Code PL"` to your VS Code's settings.json
 
 ## Set up Powerline in WSL Ubuntu
 

--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -90,7 +90,7 @@ Your Windows PowerShell profile settings.json file should now look like this:
 },
 ```
 > [!TIP]
-> If you want to support Powerline glyphs in the VS Code terminal, you can add `"terminal.integrated.fontFamily": "Cascadia Code PL"` to your VS Code's settings.json
+> If you also use the integrated terminal in Visual Studio Code, you should add `"terminal.integrated.fontFamily": "Cascadia Code PL"` to your Visual Studio Code settings to make sure Powerline works there, too.
 
 ## Set up Powerline in WSL Ubuntu
 


### PR DESCRIPTION
Added a tip on how to support powerline glyphs in VS Code's integrated terminal