### PR TITLE
Add docs for double underscore cursor

### DIFF
--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -238,13 +238,13 @@ ___
 
 ### Cursor shape
 
-This sets the cursor shape for the profile. The possible cursors are as follows: `"bar"` ( &#x2503; ), `"vintage"` ( &#x2583; ), `"underscore"` ( &#x2581; ), `"filledBox"` ( &#x2588; ), `"emptyBox"` ( &#x25AF; )
+This sets the cursor shape for the profile. The possible cursors are as follows: `"bar"` ( &#x2503; ), `"vintage"` ( &#x2583; ), `"underscore"` ( &#x2581; ), `"filledBox"` ( &#x2588; ), `"emptyBox"` ( &#x25AF; ), `"doubleUnderscore"` ( &#x2017; )
 
 **Property name:** `cursorShape`
 
 **Necessity:** Optional
 
-**Accepts:** `"bar"`, `"vintage"`, `"underscore"`, `"filledBox"`, `"emptyBox"`
+**Accepts:** `"bar"`, `"vintage"`, `"underscore"`, `"filledBox"`, `"emptyBox"`, `"doubleUnderscore"`
 
 **Default value:** `"bar"`
 


### PR DESCRIPTION
This adds the documentation for the cursor `doubleUnderscore`, as added in [microsoft/terminal#7827](https://github.com/microsoft/terminal/pull/7827).