### PR TITLE
Auto detect background image docs

### DIFF
--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -397,18 +397,6 @@ When `useAcrylic` is set to `true`, this sets the transparency of the window for
 ___
 
 ## Background image settings
-### Using the desktop background image
-
-This automatically sets the terminal's background image to match the desktop background image.
-
-**Property name:** `useDesktopBackgroundImage`
-
-**Necessity:** Optional
-
-**Accepts:** `true`, `false`
-
-**Default value:** `false`
-
 ### Setting the background image
 
 This sets the file location of the image to draw over the window background. The background image can be a .jpg, .png, or .gif file.
@@ -417,7 +405,7 @@ This sets the file location of the image to draw over the window background. The
 
 **Necessity:** Optional
 
-**Accepts:** File location as a string
+**Accepts:** File location as a string, 'DesktopWallpaper'
 
 ### Background image stretch mode
 

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -405,7 +405,7 @@ This sets the file location of the image to draw over the window background. The
 
 **Necessity:** Optional
 
-**Accepts:** 'File location as a string', '"DesktopWallpaper"''
+**Accepts:** `File location as a string`, `"DesktopWallpaper"`
 
 ### Background image stretch mode
 

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -397,6 +397,17 @@ When `useAcrylic` is set to `true`, this sets the transparency of the window for
 ___
 
 ## Background image settings
+### Using the your desktop background
+
+This automatically sets the terminal's background image to match your desktop background image.
+
+**Property name:** `useDesktopBackgroundImage`
+
+**Necessity:** Optional
+
+**Accepts:** `true`, `false`
+
+**Default value:** `false`
 
 ### Setting the background image
 

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -399,13 +399,13 @@ ___
 ## Background image settings
 ### Setting the background image
 
-This sets the file location of the image to draw over the window background. The background image can be a .jpg, .png, or .gif file.
+This sets the file location of the image to draw over the window background. The background image can be a .jpg, .png, or .gif file. Use keyword "DesktopWallpaper" to set the path to the desktop's wallpaper.
 
 **Property name:** `backgroundImage`
 
 **Necessity:** Optional
 
-**Accepts:** File location as a string, 'DesktopWallpaper'
+**Accepts:** 'File location as a string', '"DesktopWallpaper"''
 
 ### Background image stretch mode
 

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -397,7 +397,7 @@ When `useAcrylic` is set to `true`, this sets the transparency of the window for
 ___
 
 ## Background image settings
-### Using the your desktop background
+### Using the desktop background image
 
 This automatically sets the terminal's background image to match your desktop background image.
 

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -399,7 +399,7 @@ ___
 ## Background image settings
 ### Using the desktop background image
 
-This automatically sets the terminal's background image to match your desktop background image.
+This automatically sets the terminal's background image to match the desktop background image.
 
 **Property name:** `useDesktopBackgroundImage`
 


### PR DESCRIPTION
Added documentation to profile-setting.md for the setting "backgroundImage" to accept "DesktopWallpaper" as a way to mimic the desktops wallpaper as the terminals background image.

Documentation for https://github.com/microsoft/terminal/issues/7295

*I am a student and this is my first pull request for Terminal so please give feedback no matter how small. It's the best way I can learn.

