### PR TITLE
Add troubleshooting tips for the keyboard service dialog 

### DIFF
--- a/TerminalDocs/troubleshooting.md
+++ b/TerminalDocs/troubleshooting.md
@@ -100,3 +100,26 @@ Update-Module PSReadline
 Applications that use the [`GetConsoleScreenBufferInfo` family of APIs](https://docs.microsoft.com/windows/console/getconsolescreenbufferinfoex) to retrieve the active console colors in Win32 format and then attempt to transform them into cross-platform VT sequences (for example, by transforming `BACKGROUND_RED` to `\x1b[41m`) may interfere with Terminal's ability to detect what background color the application is attempting to use.
 
 Application developers are encouraged to choose either Windows API functions _or_ VT sequences for adjusting colors and not attempt to mix them.
+
+### Keyboard service warning
+
+Starting in Windows Terminal 1.5, the Terminal will display a warning if the "Touch Keyboard and Handwriting Panel Service" is disabled. This service is needed by the operating system to properly route input events to the Terminal application (as well as many other applications on Windows). If you see this warning, you can follow these steps to re-enable the service:
+1. In the run dialog, run `services.msc`
+
+  ![services.msc in the run dialog](https://user-images.githubusercontent.com/18356694/97891741-c81eed00-1cf4-11eb-9d48-7b94fede5294.png)
+
+2. Find the "Touch Keyboard and Handwriting Panel Service"
+
+  ![Touch Keyboard and Handwriting Panel Service in Services.msc](https://user-images.githubusercontent.com/18356694/97891813-e1279e00-1cf4-11eb-91c8-69a5c6da6c3d.png)
+
+3. Open the "Properties" for this service
+
+  ![service properties](https://user-images.githubusercontent.com/18356694/97891923-03212080-1cf5-11eb-90cc-821a4fbf16ba.png)
+
+4. Change the "startup type" to "Automatic"
+
+  ![service startup type](https://user-images.githubusercontent.com/18356694/97892043-25b33980-1cf5-11eb-8833-a2e65a306a79.png)
+
+5. Hit "Ok", and restart the PC.
+
+After restarting the machine, the service should auto-start, and the dialog should no longer appear.


### PR DESCRIPTION
These are the steps to re-enable the keyboard service, the one that we'll warn about in microsoft/terminal#8095.

🔔 **THERE'S NO `release-1.5` BRANCH YET** 🔔 @cinnamon-msft make sure to fix this before merge