### PR TITLE
Add backslash escape note for startingDirectory in Profile Settings

### DIFF
--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -76,6 +76,9 @@ This is the directory the shell starts in when it is loaded.
 <br />
 
 > [!NOTE]
+> Backslashes need to be escaped. For example, `C:\Users\USERNAME\Documents` should be entered as `C:\\Users\\USERNAME\\Documents`.
+
+> [!NOTE]
 > When setting the starting directory that your installed WSL distributions open to, you should use this format: `"startingDirectory": "\\\\wsl$\\DISTRO NAME\\home\\USERNAME"`, replacing with the name of your distribution. For example, `"startingDirectory": "\\\\wsl$\\Ubuntu-20.04\\home\\user1"`.
 
 > [!NOTE]


### PR DESCRIPTION
JSON values require backslashes to be escaped. Windows paths **will** have backslashes, therefore this is likely a common pitfall.

Took me a couple of minutes to remember this JSON escaping requirement, so adding note to docs so future self and others remember.

An unescaped path will result in the error shown in the screenshot, which does not immediately indicate the problem character. (My editor also counts a tab as 4 columns while the Terminal JSON parser counts a tab as one column, which made it not trivial to identify which character required escaping.)

![image](https://user-images.githubusercontent.com/1619599/99123575-70bf2d80-25ce-11eb-89c4-04116b1c9069.png)
