### PR TITLE
Warn to omit source in custom profile declaration

### DIFF
--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -61,6 +61,9 @@ This stores the name of the profile generator that originated the profile. _Ther
 
 **Accepts:** String
 
+> [!NOTE]
+> Thise field should be omitted when declaring custom profile.
+
 ### Starting directory
 
 This is the directory the shell starts in when it is loaded.

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -62,7 +62,7 @@ This stores the name of the profile generator that originated the profile. _Ther
 **Accepts:** String
 
 > [!NOTE]
-> Thise field should be omitted when declaring custom profile.
+> This field should be omitted when declaring custom profile.
 
 ### Starting directory
 

--- a/TerminalDocs/customize-settings/profile-settings.md
+++ b/TerminalDocs/customize-settings/profile-settings.md
@@ -62,7 +62,7 @@ This stores the name of the profile generator that originated the profile. _Ther
 **Accepts:** String
 
 > [!NOTE]
-> This field should be omitted when declaring custom profile.
+> This field should be omitted when declaring a custom profile. It is used by Terminal to connect automatically generated profiles to your settings file.
 
 ### Starting directory
 


### PR DESCRIPTION
If the source field specified for custom profile we fail silently. 
Let's start with documenting that this field is not expected in custom profile.
See https://github.com/microsoft/terminal/issues/8333.