### PR TITLE
Fix a typo in discussion of terminal titles

### DIFF
--- a/TerminalDocs/tutorials/tab-title.md
+++ b/TerminalDocs/tutorials/tab-title.md
@@ -43,7 +43,7 @@ A shell has full control over its own title. However, each shell sets its title 
 | Command Prompt | `TITLE "New Title"` |
 | bash* | `echo -ne "\033]0;New Title\a"` |
 
-Note that some Linux distributions (i.e. Ubuntu) set their title automatically as you interact with the shell. If the above command doesn't work, run the following command:
+Note that some Linux distributions (e.g. Ubuntu) set their title automatically as you interact with the shell. If the above command doesn't work, run the following command:
 
 ```bash
 PS1=$


### PR DESCRIPTION
"E.g." seems to be the intended meaning: There are Linux distributions that are not Ubuntu, but Ubuntu is an example of a Linux distribution for which the behavior is the given.