### PR TITLE
Powerline on old Ubuntu: Use up-to-date version of golang

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -102,6 +102,13 @@ sudo apt install golang-go
 go get -u github.com/justjanne/powerline-go
 ```
 
+> [!TIP]
+> If you're using Ubuntu 18.04 or 16.04, you'll need to first install the correct version of golang:
+> ```bash
+> sudo add-apt-repository ppa:longsleep/golang-backports
+> sudo apt update
+> ```
+
 ### Customize your Ubuntu prompt
 
 Open your `~/.bashrc` file with `nano ~/.bashrc` or the text editor of your choice. This is a bash script that runs every time bash starts. Add the following, though beware that GOPATH may already exist:


### PR DESCRIPTION
Currently, the install recommends using an out-of-date version of golang, which in turn causes issues while installing powerline-go.

### Change

Suggest users use the PPA for updating golang, as suggested by 

### Alternatives

Install the binary version of powerline-go:

```bash
mkdir -o ~/.bin/
wget https://github.com/justjanne/powerline-go/releases/latest/download/powerline-go-linux-amd64 -O ~/.bin/.powerline-go
chmod a+x ~/.bin/powerline-go
```

This would in turn require an updated snippet:
```bash
function _update_ps1() {
    PS1="$($HOME/.bin/powerline-go -error $?)"
}
if [ "$TERM" != "linux" ] && [ -f "$GOPATH/bin/powerline-go" ]; then
    PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
fi
```