### PR TITLE
fixed typo

### DIFF
--- a/TerminalDocs/command-palette.md
+++ b/TerminalDocs/command-palette.md
@@ -112,7 +112,7 @@ The above command would behave like the following three commands:
             "command": { "action": "newTab", "profile": "Command Prompt" }
         },
         {
-            "icon": "C:\\path\\to\\icon",
+            "icon": "C:\\path\\to\\icon.png",
             "name": "PowerShell",
             "command": { "action": "newTab", "profile": "PowerShell" }
         },


### PR DESCRIPTION
in line 98 it's `C:\\path\\to\\icon.png` while in line 115 is a reference to line 98 with `C:\\path\\to\\icon`. So I've added the missing `.png`