### PR TITLE
Add a doc that informs users how to install the terminal

### DIFF
--- a/TerminalDocs/index.md
+++ b/TerminalDocs/index.md
@@ -17,6 +17,10 @@ Windows Terminal is a modern terminal application for users of command-line tool
 > [!NOTE]
 > [What's the difference between a console, a terminal, and a shell?](https://www.hanselman.com/blog/WhatsTheDifferenceBetweenAConsoleATerminalAndAShell.aspx) Read Scott Hanselman's explanation.
 
+## Installing the Terminal
+
+For info on installing the Terminal, see [Installing the Windows Terminal](./install.md).
+
 ## Multiple profiles supporting a variety of command line applications
 
 Any application that has a command line interface can be run inside Windows Terminal. This includes everything from PowerShell and Command Prompt to Azure Cloud Shell and any WSL distribution such as Ubuntu or Oh-My-Zsh.

--- a/TerminalDocs/install.md
+++ b/TerminalDocs/install.md
@@ -8,11 +8,11 @@ ms.topic: overview
 ms.localizationpriority: high
 ---
 
-## Installing and running Windows Terminal
+# Installing and running Windows Terminal
 
 > Note: Windows Terminal requires Windows 10 1903 (build 18362) or later
 
-### Microsoft Store [Recommended]
+## Microsoft Store [Recommended]
 
 Install the [Windows Terminal from the Microsoft Store][store-install-link].
 This allows you to always be on the latest version when we release new builds
@@ -20,9 +20,9 @@ with automatic upgrades.
 
 This is our preferred method.
 
-### Other install methods
+## Other install methods
 
-#### Via GitHub
+### Via GitHub
 
 For users who are unable to install Windows Terminal from the Microsoft Store,
 released builds can be manually downloaded from our repository's [Releases
@@ -47,7 +47,7 @@ Add-AppxPackage Microsoft.WindowsTerminal_<versionNumber>.msixbundle
 >   to regularly install the latest Terminal release to receive all the latest
 >   fixes and improvements!
 
-#### Via Windows Package Manager CLI (aka winget)
+### Via Windows Package Manager CLI (aka winget)
 
 [winget](https://github.com/microsoft/winget-cli) users can download and install
 the latest Terminal release by installing the `Microsoft.WindowsTerminal`
@@ -57,7 +57,7 @@ package:
 winget install --id=Microsoft.WindowsTerminal -e
 ```
 
-#### Via Chocolatey (unofficial)
+### Via Chocolatey (unofficial)
 
 [Chocolatey](https://chocolatey.org) users can download and install the latest
 Terminal release by installing the `microsoft-windows-terminal` package:
@@ -77,7 +77,7 @@ If you have any issues when installing/upgrading the package please go to the
 page](https://chocolatey.org/packages/microsoft-windows-terminal) and follow the
 [Chocolatey triage process](https://chocolatey.org/docs/package-triage-process)
 
-#### Via Scoop (unofficial)
+### Via Scoop (unofficial)
 
 [Scoop](https://scoop.sh) users can download and install the latest Terminal
 release by installing the `windows-terminal` package:

--- a/TerminalDocs/install.md
+++ b/TerminalDocs/install.md
@@ -1,0 +1,102 @@
+---
+title: Installing the Windows Terminal
+description: Learn how to install the Windows Terminal
+author: cinnamon-msft
+ms.author: cinnamon
+ms.date: 03/18/2021
+ms.topic: overview
+ms.localizationpriority: high
+---
+
+## Installing and running Windows Terminal
+
+> Note: Windows Terminal requires Windows 10 1903 (build 18362) or later
+
+### Microsoft Store [Recommended]
+
+Install the [Windows Terminal from the Microsoft Store][store-install-link].
+This allows you to always be on the latest version when we release new builds
+with automatic upgrades.
+
+This is our preferred method.
+
+### Other install methods
+
+#### Via GitHub
+
+For users who are unable to install Windows Terminal from the Microsoft Store,
+released builds can be manually downloaded from our repository's [Releases
+page](https://github.com/microsoft/terminal/releases).
+
+Download the `Microsoft.WindowsTerminal_<versionNumber>.msixbundle` file from
+the **Assets** section. To install the app, you can simply double-click on the
+`.msixbundle` file, and the app installer should automatically run. If that
+fails for any reason, you can try the following command at a PowerShell prompt:
+
+```powershell
+# NOTE: If you are using PowerShell 7+, please run
+# Import-Module Appx -UseWindowsPowerShell
+# before using Add-AppxPackage.
+
+Add-AppxPackage Microsoft.WindowsTerminal_<versionNumber>.msixbundle
+```
+
+> Note: If you install Terminal manually:
+>
+> * Terminal will not auto-update when new builds are released so you will need
+>   to regularly install the latest Terminal release to receive all the latest
+>   fixes and improvements!
+
+#### Via Windows Package Manager CLI (aka winget)
+
+[winget](https://github.com/microsoft/winget-cli) users can download and install
+the latest Terminal release by installing the `Microsoft.WindowsTerminal`
+package:
+
+```powershell
+winget install --id=Microsoft.WindowsTerminal -e
+```
+
+#### Via Chocolatey (unofficial)
+
+[Chocolatey](https://chocolatey.org) users can download and install the latest
+Terminal release by installing the `microsoft-windows-terminal` package:
+
+```powershell
+choco install microsoft-windows-terminal
+```
+
+To upgrade Windows Terminal using Chocolatey, run the following:
+
+```powershell
+choco upgrade microsoft-windows-terminal
+```
+
+If you have any issues when installing/upgrading the package please go to the
+[Windows Terminal package
+page](https://chocolatey.org/packages/microsoft-windows-terminal) and follow the
+[Chocolatey triage process](https://chocolatey.org/docs/package-triage-process)
+
+#### Via Scoop (unofficial)
+
+[Scoop](https://scoop.sh) users can download and install the latest Terminal
+release by installing the `windows-terminal` package:
+
+```powershell
+scoop bucket add extras
+scoop install windows-terminal
+```
+
+To update Windows Terminal using Scoop, run the following:
+
+```powershell
+scoop update windows-terminal
+```
+
+If you have any issues when installing/updating the package, please search for
+or report the same on the [issues
+page](https://github.com/lukesampson/scoop-extras/issues) of Scoop Extras bucket
+repository.
+
+
+[store-install-link]: https://aka.ms/terminal


### PR DESCRIPTION
This is gratuitously copied from the Terminal repo's `README`.
Closes #281

Maybe we should remove the copy in the Terminal repo, and point them here?