### PR TITLE
Updated openSettings default bindings.

### DIFF
--- a/TerminalDocs/customize-settings/actions.md
+++ b/TerminalDocs/customize-settings/actions.md
@@ -205,7 +205,8 @@ This opens either the default or custom settings files. Without the `target` fie
 **Default bindings:**
 
 ```json
-{ "command": "openSettings", "keys": "ctrl+," },
+{ "command": { "action": "openSettings", "target": "settingsUI" }, "keys": "ctrl+," },
+{ "command": { "action": "openSettings", "target": "settingsFile" }, "keys": "ctrl+shift+," },
 { "command": { "action": "openSettings", "target": "defaultsFile" }, "keys": "ctrl+alt+," },
 ```
 
@@ -214,9 +215,6 @@ This opens either the default or custom settings files. Without the `target` fie
 | Name | Necessity | Accepts | Description |
 | ---- | --------- | ------- | ----------- |
 | `target` | Optional | `"settingsFile"`, `"defaultsFile"`, `"settingsUI"`, `"allFiles"` | The settings file to open. |
-
-> [!IMPORTANT]
-> The `"settingsUI"` value for `target` is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
 
 ### Toggle full screen
 


### PR DESCRIPTION
1.7.1033.0 is now stable, and so the new settings features have found their way to everyone. This is a very minor update to add the new default bindings, and remove the warning about the new settings UI being in preview.