### PR TITLE
Update configuration section of get-start

### DIFF
--- a/TerminalDocs/get-started.md
+++ b/TerminalDocs/get-started.md
@@ -42,12 +42,11 @@ You can run multiple shells side-by-side using panes. To open a pane, you can us
 
 ## Configuration
 
-To customize the settings of your Windows Terminal, select **Settings** in the dropdown menu. This will open the `settings.json` file in your default text editor. (The default text editor is defined in your [Windows settings](ms-settings:defaultapps).)
-
-The terminal supports customization of global properties that affect the whole application, [profile properties](./customize-settings/profile-general.md) that affect the settings of each profile, and [actions](./customize-settings/actions.md) that allow you to interact with the terminal using your keyboard or the command palette.
+To customize the settings of your Windows Terminal, select **Settings** in the dropdown menu. This will open the settings UI to configure your settings. You can learn how to open the settings UI on the [Actions page](./customize-settings/actions.md#application-level-commands).
 
 > [!TIP]
-> You can also use the settings UI to configure your settings if you are using [Windows Terminal Preview](https://aka.ms/terminal-preview). You can learn how to open the settings UI on the [Actions page](./customize-settings/actions.md#application-level-commands).
+> If you prefer to configure your settings by edit file, click the "setting" icon, This will open the `settings.json` file in your default text editor. (The default text editor is defined in your [Windows settings](ms-settings:defaultapps).)
+> The terminal supports customization of global properties that affect the whole application, [profile properties](./customize-settings/profile-general.md) that affect the settings of each profile, and [actions](./customize-settings/actions.md) that allow you to interact with the terminal using your keyboard or the command palette.
 
 ## Command line arguments
 


### PR DESCRIPTION
Select Settings in the dropdown menu will open the Settings UI instead of open file since the release version v1.6.10571.0
But this page is not up to date, so I edit it.