### PR TITLE
Remove V2 requirement for oh-my-posh install

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -40,7 +40,7 @@ Using PowerShell, install Posh-Git and Oh-My-Posh:
 
 ```powershell
 Install-Module posh-git -Scope CurrentUser
-Install-Module oh-my-posh -Scope CurrentUser -RequiredVersion 2.0.412
+Install-Module oh-my-posh -Scope CurrentUser
 ```
 
 > [!TIP]


### PR DESCRIPTION
Forcing the install to be powerline V2 via `-RequiredVersion 2.0.412` breaks the guide, as setting the theme in the powershell needs a different command in V2 than in V3 (the guide currently uses the V3 command for the powershell profile).

Removing the version requirement makes the install default to V3 and fixes the guide.