### PR TITLE
Remove RequiredVersion parameter

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -40,7 +40,7 @@ Using PowerShell, install Posh-Git and Oh-My-Posh:
 
 ```powershell
 Install-Module posh-git -Scope CurrentUser
-Install-Module oh-my-posh -Scope CurrentUser -RequiredVersion 2.0.412
+Install-Module oh-my-posh -Scope CurrentUser
 ```
 
 > [!TIP]


### PR DESCRIPTION
Issue: Following the instructions on this page results in a PowerShell profile error "The term 'Set-PoshPrompt' is not recognized".
Root Cause: Current documentation states to add "-RequiredVersion 2.0.412" to the Oh-My-Posh install. This installs a version that does not include the "Set-PoshPrompt" command specified in the profile modification instructions on this same page (line 68). 
Resolution: Remove the "-RequiredVersion 2.0.412" from the install command. This will install the latest Oh-My-Posh version. 
Result: PowerShell session starts correctly and without errors.