### PR TITLE
Remove MinimizeToTray action mentions

### DIFF
--- a/TerminalDocs/customize-settings/actions.md
+++ b/TerminalDocs/customize-settings/actions.md
@@ -697,23 +697,6 @@ _This command is not currently bound in the default settings_.
 > [!IMPORTANT]
 > This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
 
-### Minimize to tray ([Preview](https://aka.ms/terminal-preview))
-
-This will hide the currently focused window from the Taskbar and instead will be accessible from the system tray icon. This action will only be useable when the tray icon is visible through one of the two global settings `minimizeToTray` or `alwaysShowTrayIcon`.
-
-**Command name:** `minimizeToTray`
-
-**Default binding:**
-
-_This command is not currently bound in the default settings_.
-
-```json
-{"command": "minimizeToTray" },
-```
-
-> [!IMPORTANT]
-> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
-
 <br />
 
 ___

--- a/TerminalDocs/customize-settings/interaction.md
+++ b/TerminalDocs/customize-settings/interaction.md
@@ -107,7 +107,7 @@ ___
 
 ## Minimize to tray ([Preview](https://aka.ms/terminal-preview))
 
-When this is set to `true`, minimizing a window will hide it from the taskbar, making it inaccessible from that area. It will instead be accessible from Terminal's system tray icon. If either this global setting or the `minimizeToTray` global setting is set to true, Terminal will place an icon in the system tray. The user will also be able to utilize the `minimizeToTray` _action_.
+When this is set to `true`, minimizing a window will hide it from the taskbar, making it inaccessible from that area. It will instead be accessible from Terminal's system tray icon. If either this global setting or the `minimizeToTray` global setting is set to true, Terminal will place an icon in the system tray.
 
 **Property name:** `minimizeToTray`
 


### PR DESCRIPTION
While the `MinimizeToTray` and `AlwaysShowTrayIcon` global settings have merged, I took out the `MinimizeToTray` action from the original PR in order to put it in its own PR for more discussion. This PR just removes the bits that mention the action.