### PR TITLE
Update version of oh-my-posh to support suggested PS profile

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -40,7 +40,7 @@ Using PowerShell, install Posh-Git and Oh-My-Posh:
 
 ```powershell
 Install-Module posh-git -Scope CurrentUser
-Install-Module oh-my-posh -Scope CurrentUser -RequiredVersion 2.0.412
+Install-Module oh-my-posh -Scope CurrentUser -MinimumVersion 3.94.0
 ```
 
 > [!TIP]


### PR DESCRIPTION
The existing required version of oh-my-posh (version 2.0.412) does not support the Set-PoshPrompt command suggested in the PS profile, version 3 is required.