### PR TITLE
Add a note about deleting state.json as well

### DIFF
--- a/TerminalDocs/troubleshooting.md
+++ b/TerminalDocs/troubleshooting.md
@@ -155,4 +155,7 @@ Press Ctrl + O and Ctrl + X to Save and Exit.
 
 ## How do I reset my settings in Windows Terminal back to the default settings?
 
-To reset your settings back to the original default settings, delete your [settings.json file](./get-started.md#settings-json-file). This will cause Windows Terminal to regenerate a settings.json file with the original default settings.
+To reset your settings back to the original default settings, delete your [settings.json file](./get-started.md#settings-json-file). This will cause Windows Terminal to regenerate a `settings.json` file with the original default settings.
+
+> [!IMPORTANT]
+> As of Terminal version 1.10 or greater, you'll also need to delete the `state.json` file in the same directory as the `settings.json` file to fully reset the settings to the defaults.


### PR DESCRIPTION
"How do I reset my settings in Windows Terminal back to the default settings?" mentions deleting `settings.json` to revert back to the defaults. However, now we've got `state.json` as well, and that stores some other important info. So you need to actually delete that file to. 

Brought to our attention in https://github.com/microsoft/terminal/issues/11119