### PR TITLE
Install-Module with MinimumVersion

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -40,7 +40,7 @@ Using PowerShell, install Posh-Git and Oh-My-Posh:
 
 ```powershell
 Install-Module posh-git -Scope CurrentUser
-Install-Module oh-my-posh -Scope CurrentUser -RequiredVersion 2.0.412
+Install-Module -Name oh-my-posh -MinimumVersion 2.0.412 -Scope CurrentUser
 ```
 
 > [!TIP]


### PR DESCRIPTION
Instead of hard coding a version in the docs, we could use -MinimumVersion to ask for at least that version, which in practice will install the latest.
The WSL Ubuntu instructions are downloading the latest so it's not consistent across the 2 platforms.

Fixes #413