### PR TITLE
Bugfix: Required version broken

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -40,7 +40,7 @@ Using PowerShell, install Posh-Git and Oh-My-Posh:
 
 ```powershell
 Install-Module posh-git -Scope CurrentUser
-Install-Module oh-my-posh -Scope CurrentUser -RequiredVersion 2.0.412
+Install-Module oh-my-posh -Scope CurrentUser
 ```
 
 > [!TIP]


### PR DESCRIPTION
The required version is not working. Latest does.

Used [this comment](https://github.com/microsoft/terminal/issues/9237#issuecomment-891643150) to resolve the issue.