### PR TITLE
Update Powerline docs

### DIFF
--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -100,7 +100,11 @@ Your Windows PowerShell profile settings.json file should now look like this:
 
 ### WSL Ubuntu prerequisites
 
-Ubuntu has several Powerline options to install from. This tutorial will be using oh-my-posh for Linux:
+Ubuntu has several Powerline options to install from. This tutorial will be using oh-my-posh for Linux.
+
+> [!TIP]
+> If you're also using oh-my-posh on Windows, it's a good idea to install oh-my-posh using Winget or Scoop.
+> Follow the guide on the [oh-my-posh doc site](https://ohmyposh.dev/docs/windows) and continue with [setting up your prompt](https://docs.microsoft.com/en-us/windows/terminal/tutorials/powerline-setup#customize-your-ubuntu-prompt).
 
 First, install oh-my-posh:
 

--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -40,7 +40,7 @@ Using PowerShell, install Posh-Git and Oh-My-Posh:
 
 ```powershell
 Install-Module posh-git -Scope CurrentUser
-Install-Module oh-my-posh -Scope CurrentUser -RequiredVersion 2.0.412
+Install-Module oh-my-posh -Scope CurrentUser
 ```
 
 > [!TIP]

--- a/TerminalDocs/tutorials/powerline-setup.md
+++ b/TerminalDocs/tutorials/powerline-setup.md
@@ -120,13 +120,6 @@ chmod u+rw ~/.poshthemes/*.json
 rm ~/.poshthemes/themes.zip
 ```
 
-> [!TIP]
-> If you're using Ubuntu 18.04 or 16.04, you'll need to first install the correct version of golang:
-> ```bash
-> sudo add-apt-repository ppa:longsleep/golang-backports
-> sudo apt update
-> ```
-
 ### Customize your Ubuntu prompt
 
 Open your `~/.bashrc` file with `nano ~/.bashrc` or the text editor of your choice. This is a bash script that runs every time bash starts. Add the following (change the theme to the one you like):


### PR DESCRIPTION
A few changes:

1. There were a few comments from people getting confused by the `-RequiredVersion 2.0.412` setting to install oh-my-posh. As that's probably a leftover from a time long passed I removed it.
2. There's a mention of golang as a requirement to install oh-my-posh on WSL, that's incorrect and a leftover from powerline-go instructions.
3. To guide users to an easier installation/update experience, I added an info block with this context pointing to the oh-my-posh docs.

As a general question, I wanted to point to a relative URL in point 3, but I have no idea which one to use. If someone can point me in the right direction, would be appreciated!

relates to #420, #413, #404, #382, #370, #369, #364, #363 (the list goes on 😓 )