### PR TITLE
Bulk fix - Removing .localizationpriority

### DIFF
--- a/TerminalDocs/command-palette.md
+++ b/TerminalDocs/command-palette.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 02/25/2021
 ms.topic: how-to 
-ms.localizationpriority: high
 ---
 
 # How to use the command palette in Windows Terminal

--- a/TerminalDocs/customize-settings/actions.md
+++ b/TerminalDocs/customize-settings/actions.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/15/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Custom actions in Windows Terminal

--- a/TerminalDocs/customize-settings/appearance.md
+++ b/TerminalDocs/customize-settings/appearance.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/08/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Appearance settings in Windows Terminal

--- a/TerminalDocs/customize-settings/color-schemes.md
+++ b/TerminalDocs/customize-settings/color-schemes.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 04/14/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Color schemes in Windows Terminal

--- a/TerminalDocs/customize-settings/interaction.md
+++ b/TerminalDocs/customize-settings/interaction.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/05/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Interaction settings in Windows Terminal

--- a/TerminalDocs/customize-settings/profile-advanced.md
+++ b/TerminalDocs/customize-settings/profile-advanced.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/19/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Advanced profile settings in Windows Terminal

--- a/TerminalDocs/customize-settings/profile-appearance.md
+++ b/TerminalDocs/customize-settings/profile-appearance.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/08/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Appearance profile settings in Windows Terminal

--- a/TerminalDocs/customize-settings/profile-general.md
+++ b/TerminalDocs/customize-settings/profile-general.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 04/14/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # General profile settings in Windows Terminal

--- a/TerminalDocs/customize-settings/rendering.md
+++ b/TerminalDocs/customize-settings/rendering.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 04/14/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Rendering settings in Windows Terminal

--- a/TerminalDocs/customize-settings/startup.md
+++ b/TerminalDocs/customize-settings/startup.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/08/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Startup settings in Windows Terminal

--- a/TerminalDocs/index.md
+++ b/TerminalDocs/index.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 09/22/2020
 ms.topic: overview
-ms.localizationpriority: high
 ---
 
 # What is Windows Terminal?

--- a/TerminalDocs/install.md
+++ b/TerminalDocs/install.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/04/2021
 ms.topic: quickstart
-ms.localizationpriority: high
 ---
 
 # Install and get started setting up Windows Terminal

--- a/TerminalDocs/samples.md
+++ b/TerminalDocs/samples.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 11/16/2021
 ms.topic: samples
-ms.localizationpriority: medium
 ---
 
 # Windows Terminal sample code

--- a/TerminalDocs/tips-and-tricks.md
+++ b/TerminalDocs/tips-and-tricks.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/08/2021
 ms.topic: how-to
-ms.localizationpriority: high
 ---
 
 # Windows Terminal tips and tricks

--- a/TerminalDocs/troubleshooting.md
+++ b/TerminalDocs/troubleshooting.md
@@ -5,7 +5,6 @@ author: cinnamon-msft
 ms.author: cinnamon
 ms.date: 10/08/2021
 ms.topic: overview
-ms.localizationpriority: high
 ---
 
 # Troubleshooting in Windows Terminal


### PR DESCRIPTION
This is a bulk fix - According to the new DevRel GX group mission, the Localization production team drives the localization priority and translation quality per customer usage data, e.g. Page View or MAU of the language. The localization priority is defined by the project setting in localization pipeline - ms.localizationpriority in the source file is no longer used as a driving parameter to define the localization priority. https://review.docs.microsoft.com/help/contribute/localization-checklist-for-writer?branch=master#stop-using-mslocalizationpriority-metadata