### PR TITLE
Quoted the env-var for `setx PROMPT`

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -45,7 +45,7 @@ This will append `$e]9;9;$P$e\` to your current prompt. When cmd evaluates this 
 Note that the above command will only work for the current `cmd.exe` session. To set the value permanently, AFTER running the above command, you'll want to run
 
 ```cmd
-setx PROMPT %PROMPT%
+setx PROMPT "%PROMPT%"
 ```
 
 #### PowerShell: `powershell.exe` or `pwsh.exe`


### PR DESCRIPTION
Noticed and fixed by @tomasorti at https://github.com/microsoft/terminal/issues/3158#issuecomment-1036723763.