### PR TITLE
Add `bellsound` profile setting

### DIFF
--- a/TerminalDocs/customize-settings/profile-advanced.md
+++ b/TerminalDocs/customize-settings/profile-advanced.md
@@ -137,6 +137,23 @@ Controls what happens when the application emits a BEL character. When set to `"
 
 ___
 
+## Bell sound ([Preview](https://aka.ms/terminal-preview))
+
+When `bellStyle` is set to `"all"` or `"audible"`, this allows you to choose the audio file for the bell. If you have an array of sounds set, the terminal will pick one at random.
+
+**Property name:** `bellSound`
+
+**Necessity:** Optional
+
+**Accepts:** File location as a string or an array of file locations as strings
+
+> [!IMPORTANT]
+> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
+
+<br />
+
+___
+
 ## Experimental text rendering engine ([Preview](https://aka.ms/terminal-preview))
 
 Enables use of the experimental text rendering engine for the profile. This is an experimental feature and its continued existence is not guaranteed. A new instance of the profile needs to be opened in order for this setting to take effect.


### PR DESCRIPTION
Looks like we forgot to document `bellSound` for the 1.13 release.

Implemented here: https://github.com/microsoft/terminal/pull/11511