### PR TITLE
command-palette: simplify example for iterable commands

### DIFF
--- a/TerminalDocs/command-palette.md
+++ b/TerminalDocs/command-palette.md
@@ -78,15 +78,10 @@ Create a new tab command for each profile.
 
 ```json
 {
-    "name": "New tab",
-    "commands": [
-        {
-            "iterateOn": "profiles",
-            "icon": "${profile.icon}",
-            "name": "${profile.name}",
-            "command": { "action": "newTab", "profile": "${profile.name}" }
-        }
-    ]
+    "iterateOn": "profiles",
+    "icon": "${profile.icon}",
+    "name": "${profile.name}",
+    "command": { "action": "newTab", "profile": "${profile.name}" }
 }
 ```
 
@@ -109,22 +104,33 @@ The above command would behave like the following three commands:
 
 ```json
 {
-    "name": "New tab...",
+    "icon": null,
+    "name": "Command Prompt",
+    "command": { "action": "newTab", "profile": "Command Prompt" }
+},
+{
+    "icon": "C:\\path\\to\\icon",
+    "name": "PowerShell",
+    "command": { "action": "newTab", "profile": "PowerShell" }
+},
+{
+    "icon": null,
+    "name": "Ubuntu",
+    "command": { "action": "newTab", "profile": "Ubuntu" }
+}
+```
+
+It's also possible to combine nested and iterable commands. For example, you can combine the three "new tab" commands above under a single "New tab" entry in the command palette, as shown in the image above, in the following way:
+
+```json
+{
+    "name": "New tab",
     "commands": [
         {
-            "icon": null,
-            "name": "Command Prompt",
-            "command": { "action": "newTab", "profile": "Command Prompt" }
-        },
-        {
-            "icon": "C:\\path\\to\\icon",
-            "name": "PowerShell",
-            "command": { "action": "newTab", "profile": "PowerShell" }
-        },
-        {
-            "icon": null,
-            "name": "Ubuntu",
-            "command": { "action": "newTab", "profile": "Ubuntu" }
+            "iterateOn": "profiles",
+            "icon": "${profile.icon}",
+            "name": "${profile.name}",
+            "command": { "action": "newTab", "profile": "${profile.name}" }
         }
     ]
 }


### PR DESCRIPTION
The example for iterable commands combines an iterable command with a
nested command. Without reading the section about nested commands, it's
not immediately obvious that these are separate concepts.

Change the example for the iterable command so that it does not also use
a nested command.

Add a second, separate example that shows combining nested and iterable
commands.


---

This was not obvious to me and @zadjii-msft helped me get it right in  https://github.com/microsoft/terminal/issues/7016#issuecomment-1040374320, so I thought I could tweak the docs a little.

---

For discoverability:

* Version Independent ID: ea47990e-361e-5a4e-1b6e-1a3969cf4653