### PR TITLE
json-fragment-extensions: output GUIDs in "registry format"

### DIFF
--- a/TerminalDocs/json-fragment-extensions.md
+++ b/TerminalDocs/json-fragment-extensions.md
@@ -109,8 +109,8 @@ appNamespaceGUID = uuid.uuid5(terminalNamespaceGUID, "Git".encode("UTF-16LE").de
 # Calculate the example GUID for the 'Git Bash' profile
 profileGUID = uuid.uuid5(appNamespaceGUID, "Git Bash".encode("UTF-16LE").decode("ASCII"))
 
-# Output the GUID
-print(profileGUID)
+# Output the GUID as Windows Terminals expects it (enclosed in curly brackets)
+print(f"{{{profileGUID}}}")
 
 ```
 
@@ -127,8 +127,8 @@ terminalNamespaceGUID = uuid.UUID("{2bde4a90-d05f-401c-9492-e40884ead1d8}")
 # Calculate the example GUID for the 'Git Bash' profile
 profileGUID = uuid.uuid5(terminalNamespaceGUID, "Ubuntu".encode("UTF-16LE").decode("ASCII"))
 
-# Output the GUID
-print(profileGUID)
+# Output the GUID as Windows Terminals expects it (enclosed in curly brackets)
+print(f"{{{profileGUID}}}")
 
 ```
 

--- a/TerminalDocs/json-fragment-extensions.md
+++ b/TerminalDocs/json-fragment-extensions.md
@@ -109,7 +109,7 @@ appNamespaceGUID = uuid.uuid5(terminalNamespaceGUID, "Git".encode("UTF-16LE").de
 # Calculate the example GUID for the 'Git Bash' profile
 profileGUID = uuid.uuid5(appNamespaceGUID, "Git Bash".encode("UTF-16LE").decode("ASCII"))
 
-# Output the GUID as Windows Terminals expects it (enclosed in curly brackets)
+# Output the GUID as Windows Terminal expects it (enclosed in curly brackets)
 print(f"{{{profileGUID}}}")
 
 ```
@@ -127,7 +127,7 @@ terminalNamespaceGUID = uuid.UUID("{2bde4a90-d05f-401c-9492-e40884ead1d8}")
 # Calculate the example GUID for the 'Git Bash' profile
 profileGUID = uuid.uuid5(terminalNamespaceGUID, "Ubuntu".encode("UTF-16LE").decode("ASCII"))
 
-# Output the GUID as Windows Terminals expects it (enclosed in curly brackets)
+# Output the GUID as Windows Terminal expects it (enclosed in curly brackets)
 print(f"{{{profileGUID}}}")
 
 ```


### PR DESCRIPTION
Windows Terminal expects the 'guid' property of a profile in the
so-called "registry format" [1], i.e. enclosed in curly brackets.

The different GUID examples in TerminalDocs/json-fragment-extensions.md
are enclosed in curly brackets, but the Python script example to
generate GUIDs prints them without the enclosing curly brackets.

Use a Python f-string to print them enclosed in curly brackets.

[1] https://docs.microsoft.com/en-us/windows/terminal/customize-settings/profile-advanced#unique-identifier

---

version-independent id: "341f8755-2701-601f-5b91-98527354b3e8" 