### PR TITLE
troubleshooting: clarify WSL `startingDirectory` entry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+
+# Denote Markdown files as such
+*.md diff=markdown

--- a/TerminalDocs/troubleshooting.md
+++ b/TerminalDocs/troubleshooting.md
@@ -40,8 +40,6 @@ If you are using an earlier version of Windows Terminal, WSL may require using t
 }
 ```
 
-> [!IMPORTANT]
-> On newer versions of Windows, `startingDirectory` can accept Linux-style paths.
 
 ## Setting the tab title
 

--- a/TerminalDocs/troubleshooting.md
+++ b/TerminalDocs/troubleshooting.md
@@ -20,7 +20,7 @@ If you click on the "settings" button in the dropdown, the Terminal will attempt
 
 ## Set your WSL distribution to start in the home `~` directory when launched
 
-By default, the `startingDirectory` of a profile is `%USERPROFILE%` (`C:\Users\<YourUsername>`). This is a Windows path. For WSL distributions, the file systems are now directly referenced, as of Windows Terminal [version 1.12.3472.0](https://github.com/microsoft/terminal/releases). You can use `/home/<Your Ubuntu Username>` to directly refer to your home folder. For example, the following setting will launch the "Ubuntu-20.04" distribution in its home file path:
+By default, the `startingDirectory` of a profile is `%USERPROFILE%` (`C:\Users\<YourUsername>`). This is a Windows path. For WSL distributions, the file systems can now be directly referenced, as of Windows Terminal [version 1.11.2921.0](https://github.com/microsoft/terminal/releases/tag/v1.11.2921.0). You can use `/home/<Your Ubuntu Username>` to directly refer to your home folder. For example, the following setting will launch the "Ubuntu-20.04" distribution in its home file path:
 
 ```json
 {


### PR DESCRIPTION
Hi!

This is a PR that tries to clean up the "Set your WSL distribution to start in the home `~` directory when launched" section of the troubleshooting guide, following what I noticed in https://github.com/MicrosoftDocs/terminal/pull/455#issuecomment-1014865087. 

I also added the `diff` attribute for Markdown files in `.gitattributes` as an addon bonus :)

Full commit messages follow:


6dfd63f
~~~
troubleshooting: Linux paths support in 'startingDirectory' was added in 1.11.2921.0

In 7cd48bc (startingDirectory path for WSL no longer requires prefix,
2022-01-07), the "Set your WSL distribution to start in the home
directory" section of the troubleshooting guide was updated to mention
that WSL paths can now be directly referenced, following
microsoft/terminal@a2a6050 (When launching wsl, promote the starting
directory to --cd (#9223), 2021-08-02).

The text mentions this feature was added in Windows Terminal
1.12.3472.0, but it actually dates back to v1.11.2421.0 (Preview) and
v1.11.2921.0 (Stable).

Update the text to mention the stable version, and link to this version
in the GitHub releases. Also slightly improve the wording (s/are now/can
now be/).
~~~

---

d5a2d5c
~~~
troubleshooting: remove confusing 'Important' note about WSL 'startingDirectory'

In e7f739e (Docs updates for 1.11 release (#397), 2021-08-31), an
"Important" note was added to the "Set your WSL distribution to start in
the home directory" section of the troubleshooting page to mention that
'startingDirectory' now accepts Linux-style paths, following
microsoft/terminal@a2a6050 (When launching wsl, promote the starting
directory to --cd (#9223), 2021-08-02).

The note mentions that Linux-styled paths were accepted "on newer
versions of Windows", presumably meaning newer than 1903. Indeed, that
version was at the time mentioned in the text as the first Windows
vesion supporting the '//wsl$/' P9 prefix (it had been mentioned since
the WSL startingDirectory troubleshooting entry was created in da815cc
(Review troubleshooting page, 2020-05-04).

The text of the section was updated in 7cd48bc (startingDirectory path
for WSL no longer requires prefix, 2022-01-07) to add an example with a
Linux-style path, and to mention that this feature was added in Windows
Terminal itself (not in Windows), thus removing the mention of Windows
1903. However, the "Important" note was left, and it still confusingly
mentions that Linux-style paths are accepted on "newer" versions of
Windows, without mentioning newer than what.

Remove the note altogether.
~~~

---


396c847:
~~~
.gitattributes: mark '*.md' as Markdown files

Denote Markdown files as such with the 'diff' Git attribute [1]. This
allows various Git commands (diff [2, 3], grep [4, 5], log [6], blame
[7]) to show in which part of the "code" the changes are located in the
hunk header, i.e. the previous commit would be shown as

    diff --git a/TerminalDocs/troubleshooting.md
    b/TerminalDocs/troubleshooting.md
    index 4a880fa..2c9d14d 100644
    --- a/TerminalDocs/troubleshooting.md
    +++ b/TerminalDocs/troubleshooting.md
    @@ -40,8 +40,6 @@ ## Set your WSL distribution to start in the home `~` directory when launched
     }
     ```

    -> [!IMPORTANT]
    -> On newer versions of Windows, `startingDirectory` can accept Linux-style paths.

     ## Setting the tab title

Notice how the hunk header indicates the changes are in the "Set your
WSL distribution to start in the home" section.

The history of that specific entry can now be interrogated using

    git log -L:"Set your WSL distribution":TerminalDocs/troubleshooting.md

[1] https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header
[2] https://git-scm.com/docs/git-diff#_generating_patch_text_with_p
[3] https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--W
[4] https://git-scm.com/docs/git-grep#Documentation/git-grep.txt--p
[5] https://git-scm.com/docs/git-grep#Documentation/git-grep.txt--W
[6] https://git-scm.com/docs/git-log#Documentation/git-log.txt--Lltfuncnamegtltfilegt
[7] https://git-scm.com/docs/git-blame#Documentation/git-blame.txt--Lltfuncnamegt
~~~

---
version-independent id: "e76f9f11-cb0d-95be-7e04-8a9137252e2d"