### PR TITLE
Update new-tab-same-directory.md

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -115,10 +115,10 @@ Once you've got the shell configured to tell the Terminal what the current direc
 
 ### Open a new tab with `duplicateTab`
 
-To open a new tab with the same path (and profile) as the currently active terminal, use the "Duplicate Tab" action. This is bound by default to <kbd>ctrl+alt+d</kbd>, as follows:
+To open a new tab with the same path (and profile) as the currently active terminal, use the "Duplicate Tab" action. This is bound by default to <kbd>alt+shift+d</kbd>, as follows:
 
 ```json
-        { "command": "duplicateTab", "keys": "ctrl+shift+d" },
+        { "command": "duplicateTab", "keys": "alt+shift+d" },
 ```
 
 (see [`duplicateTab`](../customize-settings/actions.md#duplicate-tab)) for more details.

--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -115,7 +115,7 @@ Once you've got the shell configured to tell the Terminal what the current direc
 
 ### Open a new tab with `duplicateTab`
 
-To open a new tab with the same path (and profile) as the currently active terminal, use the "Duplicate Tab" action. This is bound by default to <kbd>ctrl+shift+d</kbd>, as follows:
+To open a new tab with the same path (and profile) as the currently active terminal, use the "Duplicate Tab" action. This is bound by default to <kbd>ctrl+alt+d</kbd>, as follows:
 
 ```json
         { "command": "duplicateTab", "keys": "ctrl+shift+d" },


### PR DESCRIPTION
now the default shortcut is alt+shift+d instead of ctrl+shift+d