### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2,27 +2,27 @@
     "redirections": [
         {
             "source_path": "TerminalDocs/customize-settings/key-bindings.md",
-            "redirect_url": "https://docs.microsoft.com/windows/terminal/customize-settings/actions",
+            "redirect_url": "/windows/terminal/customize-settings/actions",
             "redirect_document_id": true
         },
         {
             "source_path": "TerminalDocs/customize-settings/global-settings.md",
-            "redirect_url": "https://docs.microsoft.com/windows/terminal/customize-settings/startup",
+            "redirect_url": "/windows/terminal/customize-settings/startup",
             "redirect_document_id": true
         },
         {
             "source_path": "TerminalDocs/customize-settings/profile-settings.md",
-            "redirect_url": "https://docs.microsoft.com/windows/terminal/customize-settings/profile-general",
+            "redirect_url": "/windows/terminal/customize-settings/profile-general",
             "redirect_document_id": true
         },
         {
             "source_path": "TerminalDocs/get-started.md",
-            "redirect_url": "https://docs.microsoft.com/windows/terminal/install",
+            "redirect_url": "/windows/terminal/install",
             "redirect_document_id": true
         },
         {
             "source_path": "TerminalDocs/tutorials/powerline-setup.md",
-            "redirect_url": "https://docs.microsoft.com/windows/terminal/tutorials/custom-prompt-setup",
+            "redirect_url": "/windows/terminal/tutorials/custom-prompt-setup",
             "redirect_document_id": true
         }
     ]


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Content & Learning team is fixing build validation errors on docs.microsoft.com for the rest of H2. This will eliminate potential accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only build validation fixes and does not change other content.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: @MonicaRush
