### PR TITLE
Fixes position of `Use a background image for the entire window`

### DIFF
--- a/TerminalDocs/customize-settings/appearance.md
+++ b/TerminalDocs/customize-settings/appearance.md
@@ -219,6 +219,9 @@ When this is set to `true`, closing a window with multiple tabs open _will_ requ
 :::column span="":::
 ![Windows Terminal confirm close all tabs](./../images/confirm-close-all-tabs.png)
 
+:::column-end:::
+:::row-end:::
+
 <br />
 
 ___


### PR DESCRIPTION
Adds missing `:::column-end::: :::row-end:::` after `Show close all tabs popup` so that `Use a background image for the entire window` takes the whole line and not only the right part of it.