### PR TITLE
Add double quotes to $PWD on line 148

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -145,7 +145,7 @@ For MINGW, Git Bash and Cygwin, you need to modify the `PROMT_COMMAND` for WSL: 
 Add the following line to the end of your `.bashrc` file:
 
 ```bash
-PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}'printf "\e]9;9;%s\e\\" "`cygpath -w $PWD`"'
+PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}'printf "\e]9;9;%s\e\\" "`cygpath -w "$PWD"`"'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
This will help print the current working directory correctly if it has a space in its name. It was previously stated on line 109 in the WSL example.