### PR TITLE
Add missing code block closing backticks

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -98,6 +98,7 @@ function Invoke-Starship-PreCommand {
   }
   $host.ui.Write($prompt)
 }
+```
 
 ### WSL
 


### PR DESCRIPTION
Adds missing code block closing backticks on line 101 which was causing the following sections to render incorrectly.