### PR TITLE
Fix missing escape in Powershell example

### DIFF
--- a/TerminalDocs/command-line-arguments.md
+++ b/TerminalDocs/command-line-arguments.md
@@ -468,7 +468,7 @@ wt --colorScheme Vintage ; split-pane --colorScheme "Tango Light"
 #### [PowerShell](#tab/powershell)
 
 ```powershell
-wt --colorScheme Vintage ; split-pane --colorScheme "Tango Light"
+wt --colorScheme Vintage `; split-pane --colorScheme "Tango Light"
 ```
 
 #### [Linux](#tab/linux)


### PR DESCRIPTION
The example for the colorscheme command was missing the escape backtick in front of the command separator.