### PR TITLE
Fix Provider path in PowerShell OSC 9;9 samples

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -56,9 +56,12 @@ Add the following to your [PowerShell profile](/powershell/module/microsoft.powe
 
 ```powershell
 function prompt {
-  $loc = $($executionContext.SessionState.Path.CurrentLocation);
+  $loc = $executionContext.SessionState.Path.CurrentLocation;
+
   $out = "PS $loc$('>' * ($nestedPromptLevel + 1)) ";
-  $out += "$([char]27)]9;9;`"$loc`"$([char]27)\"
+  if ($loc.Provider.Name -eq "FileSystem") {
+    $out += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
+  }
   return $out
 }
 ```
@@ -77,7 +80,7 @@ function prompt
   $prompt += "$([char]27)]9;12$([char]7)"
   if ($loc.Provider.Name -eq "FileSystem")
   {
-    $prompt += "$([char]27)]9;9;`"$($loc.Path)`"$([char]7)"
+    $prompt += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
   }
 
   $prompt
@@ -90,11 +93,11 @@ If you're using [Starship](http://starship.rs/), then that will already modify y
 
 ```powershell
 function Invoke-Starship-PreCommand {
-  $loc = $($executionContext.SessionState.Path.CurrentLocation);
+  $loc = $executionContext.SessionState.Path.CurrentLocation;
   $prompt = "$([char]27)]9;12$([char]7)"
   if ($loc.Provider.Name -eq "FileSystem")
   {
-    $prompt += "$([char]27)]9;9;`"$($loc.Path)`"$([char]7)"
+    $prompt += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
   }
   $host.ui.Write($prompt)
 }


### PR DESCRIPTION
The `Path` property of a PowerShell location is often a fully-qualified provider path. For normal local filesystem paths, this doesn't actually matter: `Path` will be `C:\Windows`, or whatever.

However, if your current location is a network share you get something completely different:

```
PS> (get-location).path
Microsoft.PowerShell.Core\FileSystem::\\10.128.1.49\ephemeral
```

Switching to ProviderPath ameliorates this issue.

I also took this opportunity to:
1. Make sure we only use `OSC 9;9` for _filesystem paths_ in the default prompt case
2. Switch to the correct string terminator `ST` (instead of `BEL`)