### PR TITLE
add the adobe-target metadata for A/B testing

### DIFF
--- a/TerminalDocs/docfx.json
+++ b/TerminalDocs/docfx.json
@@ -51,7 +51,8 @@
       "ms.technology": "windows-terminal",
       "searchScope": ["terminal"],
       "ms.author": "cinnamon",
-      "author": "cinnamon-msft"
+      "author": "cinnamon-msft",
+      "adobe-target": true
     },
     "fileMetadata": {},
     "template": [],


### PR DESCRIPTION
@nguyen-dows @mattwoj  could you please help to merge this metadata change (adobe-target=true) to main branch and then to live? This is to enable A/B testing ability across many url base paths so we can improve Learn user experience based on data-driven decisions. This meta (adobe-target) itself will not change how your content is displayed or modify any other UI behaviors so it is safe to merge.