### PR TITLE
Remove enableReadOnlyMode and disableReadyOnlyMode docs in panes

### DIFF
--- a/TerminalDocs/panes.md
+++ b/TerminalDocs/panes.md
@@ -224,27 +224,6 @@ You can toggle read-only mode on a pane with the `toggleReadOnlyMode` command.
 { "command": "toggleReadOnlyMode" }
 ```
 
-You can enable read-only mode on a pane. This works similarly to toggling, however, will not switch state if triggered again.
-
-**Command name:** `enableReadOnlyMode`
-
-**Default bindings:**
-
-```json
-{ "command": "enableReadOnlyMode" }
-```
-
-You can disable read-only mode on a pane. This works similarly to toggling, however, will not switch state if triggered again.
-
-**Command name:** `disableReadOnlyMode`
-
-**Default bindings:**
-
-```json
-{ "command": "disableReadOnlyMode" }
-```
-
-
 ## Customizing panes using key bindings
 
 You can customize what opens inside a new pane depending on your custom key bindings.


### PR DESCRIPTION
This PR remove `enableReadOnlyMode` and `disableReadyOnlyMode` docs in `panes.md` until it goes live in a future release. 

Those docs have already been saved in a [release branch](https://github.com/MicrosoftDocs/terminal/blob/release-1.18/TerminalDocs/panes.md#marking-a-pane-as-read-only) (`release-1.18`) so all we need to do is remove them from `main`.