### PR TITLE
Add preview text and re-add missing enableReadOnlyMode docs

### DIFF
--- a/TerminalDocs/customize-settings/actions.md
+++ b/TerminalDocs/customize-settings/actions.md
@@ -858,6 +858,30 @@ You can mark a pane as read-only, which will prevent input from going into the t
 { "command": "toggleReadOnlyMode" }
 ```
 
+You can enable read-only mode on a pane. This works similarly to toggling, however, will not switch state if triggered again.
+
+**Command name:** `enableReadOnlyMode`
+
+**Default bindings:**
+
+```json
+{ "command": "enableReadOnlyMode" }
+```
+> [!IMPORTANT]
+> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
+
+You can disable read-only mode on a pane. This works similarly to toggling, however, will not switch state if triggered again.
+
+**Command name:** `disableReadOnlyMode`
+
+**Default bindings:**
+
+```json
+{ "command": "disableReadOnlyMode" }
+```
+> [!IMPORTANT]
+> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
+
 ### Split a pane
 
 This halves the size of the active pane and opens another. Without any arguments, this will open the default profile in the new pane. If an action is not specified, the default profile's equivalent setting will be used.

--- a/TerminalDocs/customize-settings/themes.md
+++ b/TerminalDocs/customize-settings/themes.md
@@ -195,6 +195,9 @@ Configures how the "close" button on the tab should appear. This accepts the fol
 * `"never"`: Never show tab close buttons. This also disables the ability to close the tab with the middle mouse button.
 * `"activeOnly"`: Show the tab close button on the active tab only.
 
+> [!IMPORTANT]
+> The `"activeOnly"` value is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
+
 **Property name:** `showCloseButton`
 
 **Necessity:** Optional

--- a/TerminalDocs/panes.md
+++ b/TerminalDocs/panes.md
@@ -234,6 +234,9 @@ You can enable read-only mode on a pane. This works similarly to toggling, howev
 { "command": "enableReadOnlyMode" }
 ```
 
+> [!IMPORTANT]
+> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
+
 You can disable read-only mode on a pane. This works similarly to toggling, however, will not switch state if triggered again.
 
 **Command name:** `disableReadOnlyMode`
@@ -244,6 +247,8 @@ You can disable read-only mode on a pane. This works similarly to toggling, howe
 { "command": "disableReadOnlyMode" }
 ```
 
+> [!IMPORTANT]
+> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
 
 ## Customizing panes using key bindings
 


### PR DESCRIPTION
This PR adds the below preview text to instances of `enableReadOnlyMode` and `disableReadOnlyMode` in our docs (specifically in `actions.md` and `panes.md`)
```
`> [!IMPORTANT]
> This feature is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
```

This PR also adds the below preview text to the `activeOnly` value for the 'showCloseButton' property in `TerminalDocs/customize-settings/themes.md`.
```
> [!IMPORTANT]
> The `"activeOnly"` value is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
```

Lastly, this PR re-adds the missing `enableReadOnlyMode` docs in `TerminalDocs/customize-settings/actions.md` that was accidentally removed in PR #660 