### PR TITLE
Update the PowerShell example to work around a PSReadLine issue

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -58,10 +58,11 @@ Add the following to your [PowerShell profile](/powershell/module/microsoft.powe
 function prompt {
   $loc = $executionContext.SessionState.Path.CurrentLocation;
 
-  $out = "PS $loc$('>' * ($nestedPromptLevel + 1)) ";
+  $out = ""
   if ($loc.Provider.Name -eq "FileSystem") {
     $out += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
   }
+  $out += "PS $loc$('>' * ($nestedPromptLevel + 1)) ";
   return $out
 }
 ```


### PR DESCRIPTION
PSReadLine cuts a substring since the last non-whitespace character in the prompt as the error prompt [1], which is displayed when there are syntax errors. As a result, when the prompt ends in `$([char]27)\`, as in the previous example, an unexpected backslash may appear.

See: https://github.com/PowerShell/PSReadLine/issues/3719

[1] https://github.com/PowerShell/PSReadLine/blob/v2.2.6/PSReadLine/ReadLine.cs#L819.

---

Closes https://github.com/MicrosoftDocs/terminal/issues/597