### PR TITLE
Fix LastExitCode handling in the shell integration pwsh sample

### DIFF
--- a/TerminalDocs/tutorials/shell-integration.md
+++ b/TerminalDocs/tutorials/shell-integration.md
@@ -88,8 +88,12 @@ function Global:__Terminal-Get-LastExitCode {
   if ($? -eq $True) {
     return 0
   }
-  if ("$LastExitCode" -ne "") { return $LastExitCode }
-  return -1
+  $LastHistoryEntry = $(Get-History -Count 1)
+  $IsPowerShellError = $Error[0].InvocationInfo.HistoryId -eq $LastHistoryEntry.Id
+  if ($IsPowerShellError) {
+    return -1
+  }
+  return $LastExitCode
 }
 
 function prompt {


### PR DESCRIPTION
The pwsh example for the shell integration does not report an error code once `$LastExitCode` is set to 0.

Try:

```
PS > cmd /c exit 0
PS > a
```

![image](https://github.com/MicrosoftDocs/terminal/assets/81177095/67d1a20a-2879-47d4-ad75-808f9be2c44a)

This PR fixes this issue by detecting external command errors using the history and the `$Error` variable.