### PR TITLE
Update  'cmder' & 'Cygwin' dynamic-profiles.md

### DIFF
--- a/TerminalDocs/dynamic-profiles.md
+++ b/TerminalDocs/dynamic-profiles.md
@@ -59,7 +59,7 @@ Assuming that you've installed cmder into `%CMDER_ROOT%`:
 
 ```json
 {
-    "commandline": "cmd.exe /k \"%CMDER_ROOT%\\vendor\\init.bat\"",
+    "commandline": "cmd.exe /k %CMDER_ROOT%\\vendor\\init.bat",
     "name": "cmder",
     "icon": "%CMDER_ROOT%\\icons\\cmder.ico",
     "startingDirectory": "%USERPROFILE%"
@@ -68,14 +68,14 @@ Assuming that you've installed cmder into `%CMDER_ROOT%`:
 
 ### Cygwin
 
-Assuming that you've installed Cygwin into `C:\Cygwin`:
+Assuming that you've installed Cygwin into `C:\cygwin64`:
 
 ```json
 {
     "name": "Cygwin",
-    "commandline": "C:\\Cygwin\\bin\\bash --login -i",
-    "icon": "C:\\Cygwin\\Cygwin.ico",
-    "startingDirectory": "C:\\Cygwin\\bin"
+    "commandline": "C:\\cygwin64\\bin\\bash --login -i",
+    "icon": "C:\\cygwin64\\Cygwin.ico",
+    "startingDirectory": "C:\\cygwin64\\bin"
 }
 ```
 


### PR DESCRIPTION
The values for cmder and Cygwin have changed,
- Cygwin is normally installed into "C:\cygwin64" instead of "C:\Cygwin"

- cmder json commandline doesn't need the ' " ' after ' /k '

![image](https://github.com/MicrosoftDocs/terminal/assets/128968711/78a260d1-8165-4512-9d77-c221d659ce57)
![image](https://github.com/MicrosoftDocs/terminal/assets/128968711/bc540550-8ab3-44a5-9d7a-e4f0e14797b5)


Thank-You :) 