### PR TITLE
Fix breadcrumbs

### DIFF
--- a/TerminalDocs/breadcrumb/toc.yml
+++ b/TerminalDocs/breadcrumb/toc.yml
@@ -1,11 +1,3 @@
 - name: Windows
   tocHref: /windows/
-  topicHref: /windows/
-  items:
-    - name: Development environment
-      tocHref: /windows/dev-environment/overview
-      topicHref: /windows/dev-environment/overview
-      items:
-        - name: Windows Terminal
-          tocHref: /windows/terminal/
-          topicHref: /windows/terminal/
+  topicHref: /windows/index

--- a/TerminalDocs/docfx.json
+++ b/TerminalDocs/docfx.json
@@ -41,7 +41,6 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/windows/terminal/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "uhfHeaderId": "MSDocsHeader-Windows",
       "keywords": "Windows Terminal, terminal, windows shell, terminal docs",
       "feedback_system": "GitHub",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 