### PR TITLE
Add note about Profile index adjustments

### DIFF
--- a/TerminalDocs/customize-settings/profile-general.md
+++ b/TerminalDocs/customize-settings/profile-general.md
@@ -21,6 +21,11 @@ The settings listed below are specific to each unique profile. If you'd like a s
     // PROFILE OBJECTS
 ]
 ```
+## Profile order (index)
+
+The ordering of profiles in the `"list"` determines the profile index numbering. This is used to map to the launch key combo, such as Ctrl+Shift+1.
+To change the profile index number, simply cut/paste the profile objects above or below each other.
+The first in the `"list"` will map to index 1, hence, it will be assigned to the key combo, Ctrl+Shift+1.
 
 ## Name
 

--- a/TerminalDocs/customize-settings/profile-general.md
+++ b/TerminalDocs/customize-settings/profile-general.md
@@ -21,7 +21,7 @@ The settings listed below are specific to each unique profile. If you'd like a s
     // PROFILE OBJECTS
 ]
 ```
-## Profile order (index)
+## Profile Ordering
 
 The ordering of profiles in the `"list"` determines the profile index numbering. This is used to map to the launch key combo, such as <kbd>Ctrl+Shift+1</kbd>.
 To change the profile index number, simply cut/paste the profile objects above or below each other.

--- a/TerminalDocs/customize-settings/profile-general.md
+++ b/TerminalDocs/customize-settings/profile-general.md
@@ -23,9 +23,9 @@ The settings listed below are specific to each unique profile. If you'd like a s
 ```
 ## Profile order (index)
 
-The ordering of profiles in the `"list"` determines the profile index numbering. This is used to map to the launch key combo, such as Ctrl+Shift+1.
+The ordering of profiles in the `"list"` determines the profile index numbering. This is used to map to the launch key combo, such as <kbd>Ctrl+Shift+1</kbd>.
 To change the profile index number, simply cut/paste the profile objects above or below each other.
-The first in the `"list"` will map to index 1, hence, it will be assigned to the key combo, Ctrl+Shift+1.
+The first in the `"list"` will map to index 1, hence, it will be assigned to the key combo, <kbd>Ctrl+Shift+1</kbd>.
 
 ## Name
 


### PR DESCRIPTION
FIXES #768
There is currently no documentation about "profile index" and actually how to adjust this or what affects it.  The "profile index" directly affects the key combo to launch, such as Ctrl+Shift+1

- This helps tell users how to adjust the index numbering, and hence control the assigned key combo to launch.