### PR TITLE
Update new-tab-same-directory.md to mention OSC 9;9

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -14,7 +14,7 @@ Typically, the "new tab" and "split pane" actions will always open a new tab/pan
 
 Unfortunately, on Windows, it's tricky to determine what the current working directory ("CWD") for a process is. Even if we were able to look it up, not all applications actually set their CWD as they navigate. Notably, Windows PowerShell doesn't change its CWD as you `cd` around the file system! Duplicating the CWD of PowerShell automatically would almost always be wrong.
 
-Fortunately, there's a workaround. Applications can emit a special escape sequence (specifically the "osc 9;9" format) to manually tell the Terminal what the CWD should be.
+Fortunately, there's a workaround. Applications can emit a special escape sequence (specifically the "OSC 9;9" format) to manually tell the Terminal what the CWD should be.
 
 In this tutorial, you learn how to:
 

--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -14,7 +14,7 @@ Typically, the "new tab" and "split pane" actions will always open a new tab/pan
 
 Unfortunately, on Windows, it's tricky to determine what the current working directory ("CWD") for a process is. Even if we were able to look it up, not all applications actually set their CWD as they navigate. Notably, Windows PowerShell doesn't change its CWD as you `cd` around the file system! Duplicating the CWD of PowerShell automatically would almost always be wrong.
 
-Fortunately, there's a workaround. Applications can emit a special escape sequence to manually tell the Terminal what the CWD should be.
+Fortunately, there's a workaround. Applications can emit a special escape sequence (specifically the "osc 9;9" format) to manually tell the Terminal what the CWD should be.
 
 In this tutorial, you learn how to:
 


### PR DESCRIPTION
The docs mention using a specific escape sequence, but they don't mention the name.

I've added a mention to OSC 9;9 as often shell themes / tools refer to the escape sequence by name. This gives users trying to enable this feature in their tools something to search for.