### PR TITLE
Fix Syntax Error in Windows Terminal Documentation for Duplicating Tabs in Bash Shell on WSL

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -113,7 +113,7 @@ Windows Subsystem for Linux distributions primarily use BASH as the command line
 Add the following line to the end of your `.bash_profile` config file:
 
 ```bash
-PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
+PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
 ```
 
 The `PROMPT_COMMAND` variable in bash tells bash what command to run before displaying the prompt. The `printf` statement is what we're using to append the sequence for setting the working directory with the Terminal. The `$(wslpath -w "$PWD")` bit will invoke the `wslpath` executable to convert the current directory into its Windows-like path. The `${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}` bit is [some bash magic](https://unix.stackexchange.com/a/466100) to make sure we append this command to any existing command (if you've already set `PROMPT_COMMAND` somewhere else.)


### PR DESCRIPTION
## Description
This pull request addresses an issue in the Windows Terminal documentation tutorial for creating new tabs in the same directory within the WSL Ubuntu environment. The provided code snippet, when added to the end of `.bashrc`, results in a syntax error if any plugins that altered `PROMPT_COMMAND` were sourced earlier, such as `pyenv` or `rupa/z`.

## Issue
When following the documentation and adding the following code to `.bashrc`:
```sh
PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```
It results in the following error:
```sh
-bash: PROMPT_COMMAND: line 1: syntax error near unexpected token `;;'
-bash: PROMPT_COMMAND: line 1: `(_z --add "$(command pwd -P 2>/dev/null)" 2>/dev/null &);; printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"' # 
```
This happens because the provided code appends `; ` to the existing `PROMPT_COMMAND` if it is already set:
```sh
PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```
If a plugin such as `rupa/z` has already added a command to `PROMPT_COMMAND` (which typically ends with a semicolon), the resulting `PROMPT_COMMAND` contains an extra `;`, leading to a syntax error:
```sh
# Example of PROMPT_COMMAND before adding the new code:
PROMPT_COMMAND='(_z --add "$(command pwd -P 2>/dev/null)" 2>/dev/null &);'

# After adding the new code, it becomes:
PROMPT_COMMAND='(_z --add "$(command pwd -P 2>/dev/null)" 2>/dev/null &);; printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```

## Fix
To resolve this issue, we need to remove the extra semicolon causing the error and modify the code as follows:
```sh
PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```
This way, the code ensures that only a single space is added between existing commands in `PROMPT_COMMAND`:
```sh
# Example of PROMPT_COMMAND before adding the new code:
PROMPT_COMMAND='(_z --add "$(command pwd -P 2>/dev/null)" 2>/dev/null &);'

# After adding the new code, it becomes:
PROMPT_COMMAND='(_z --add "$(command pwd -P 2>/dev/null)" 2>/dev/null &) printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```

## Documentation Update
This pull request updates the documentation to include the corrected code snippet for adding to `.bashrc` without causing syntax errors. This ensures users can duplicate tabs in Windows Terminal in the same directory without issues.

---

### Before
```sh
PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND; "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```

### After
```sh
PROMPT_COMMAND=${PROMPT_COMMAND:+"$PROMPT_COMMAND "}'printf "\e]9;9;%s\e\\" "$(wslpath -w "$PWD")"'
```

---

## Testing
Tested in WSL Ubuntu environment by:
1. Adding the corrected code snippet to `.bashrc`.
2. Duplicating a tab with CTRL-SHIFT-D.
3. Confirming the new tab opens in the same directory without any syntax errors.

## Conclusion
This change provides a reliable method for duplicating tabs in the same directory within Windows Terminal, enhancing the user experience and avoiding syntax errors in `.bashrc`.