### PR TITLE
Add back accidentally-deleted BEL character

### DIFF
--- a/TerminalDocs/tutorials/progress-bar-sequences.md
+++ b/TerminalDocs/tutorials/progress-bar-sequences.md
@@ -79,7 +79,7 @@ Console.Write("\x1b]9;4;1;50\x07");
 Command Prompt is a little trickier, since it doesn't have great support for escape sequences. You can use the `echo` command to send the escape sequence, but you'll need to use literal ESC and BEL characters in the file. These might be rendered as boxes in the web browser, but they should work in the terminal.
 
 ```bat
-<NUL set /p =]9;4;1;50 
+<NUL set /p =]9;4;1;50
 echo Started progress (normal, 50)
 ```
 


### PR DESCRIPTION
The BEL character seems to have been accidentally removed somewhere down the line. I restored it from the original version of the file.