### PR TITLE
Add WSL prerequisites

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -108,6 +108,11 @@ function Invoke-Starship-PreCommand {
 
 Windows Subsystem for Linux distributions primarily use BASH as the command line shell.
 
+#### Prerequisites 
+
+Make sure your `commandline` setting is targeting the `wsl.exe -d <distro>` file, not the `<distro>.exe` file.  
+For example, use `C:\\WINDOWS\\system32\\wsl.exe -d Ubuntu-24.04` instead of `Ubuntu-24.04.exe`.
+
 #### `bash`
 
 Add the following line to the end of your `.bash_profile` config file:

--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -111,7 +111,7 @@ Windows Subsystem for Linux distributions primarily use BASH as the command line
 #### Prerequisites 
 
 Make sure your `commandline` setting is targeting the `wsl.exe -d <distro>` file, not the `<distro>.exe` file.  
-For example, use `C:\\WINDOWS\\system32\\wsl.exe -d Ubuntu-24.04` instead of `Ubuntu-24.04.exe`.
+For example, use `C:\\WINDOWS\\system32\\wsl.exe -d Ubuntu-24.04` instead of `Ubuntu2404.exe`.
 
 #### `bash`
 


### PR DESCRIPTION
See https://github.com/microsoft/terminal/issues/3158#issuecomment-2789336476.

> For those struggling to duplicate/split WSL tabs in same diretory, please ensure that the startup command line for the distribution profile uses wsl -d <distro> instead of ubuntu2204.exe like executable, as for some reason this affects the passing of the CWD.

Couldn't figure out why it didn't work on my new ubuntu instance, the comment above saved me from an headache so I guess it wouldn't hurt to add it to the documentation.