### PR TITLE
Update shell-integration.md for powershell-5

### DIFF
--- a/TerminalDocs/tutorials/shell-integration.md
+++ b/TerminalDocs/tutorials/shell-integration.md
@@ -123,9 +123,9 @@ function prompt {
   if ($Global:__LastHistoryId -ne -1) {
     if ($LastHistoryEntry.Id -eq $Global:__LastHistoryId) {
       # Don't provide a command line or exit code if there was no history entry (eg. ctrl+c, enter on no command)
-      $out += "`e]133;D`a"
+      $out += "$([char]0x1b)]133;D$([char]07)"
     } else {
-      $out += "`e]133;D;$gle`a"
+      $out += "$([char]0x1b)]133;D;$gle$([char]07)"
     }
   }
 
@@ -133,16 +133,16 @@ function prompt {
   $loc = $($executionContext.SessionState.Path.CurrentLocation);
 
   # Prompt started
-  $out += "`e]133;A$([char]07)";
+  $out += "$([char]0x1b)]133;A$([char]07)";
 
   # CWD
-  $out += "`e]9;9;`"$loc`"$([char]07)";
+  $out += "$([char]0x1b)]9;9;`"$loc`"$([char]07)";
 
   # (your prompt here)
   $out += "PWSH $loc$('>' * ($nestedPromptLevel + 1)) ";
 
   # Prompt ended, Command started
-  $out += "`e]133;B$([char]07)";
+  $out += "$([char]0x1b)]133;B$([char]07)";
 
   $Global:__LastHistoryId = $LastHistoryEntry.Id
 


### PR DESCRIPTION
```
PS C:\Users> $PSVersionTable.PSVersion

Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      19041  5848

PS C:\Users> echo "`e]133;D`a"
e]133;D   # this dings too!!
PS C:\Users> echo "$([char]0x1b)]133;D`a"
# no output, no ding (as it should)
PS C:\Users> echo "$([char]0x1b)]133;D$([char]07)"
# no output, no ding (as it should)
PS C:\Users> echo "$([char]07)"
# dings as expected
```

Maybe one could argue to make it 
```powershell
$esc = [char]0x1b
$bel = [char]0x07
$out += "${esc}]133;D;$gle${bel}" ...
```
but i got no idea how slow/fast the individual invokes might be ;)