### PR TITLE
Update --pos tag behavior for single-value input

### DIFF
--- a/TerminalDocs/command-line-arguments.md
+++ b/TerminalDocs/command-line-arguments.md
@@ -37,7 +37,7 @@ Below is the full list of supported commands and options for the `wt` command li
 | `--maximized, -M` | Launches the terminal maximized. |
 | `--fullscreen, -F` | Launches the terminal as full screen. |
 | `--focus, -f` | Launches the terminal in the focus mode. Can be combined with `maximized`. |
-| `--pos x,y` | Launches the terminal at the given position. `x` or `y` can be omitted, to use the default value from the settings. |
+| `--pos x,y` | Launches the terminal at the given position. You can provide one value to set both `x` and `y`, or use a comma to set just one and use the default for the other (e.g., `--pos 500,`). |
 | `--size` `c,r` | Launches the terminal with the specified number of columns (`c`) and rows (`r`). |
 | `--window, -w window-id` | Runs the given command in a specific window. |
 


### PR DESCRIPTION
## Summary of the Pull Request
Updated the behavior of the `--pos` command-line argument in documentation.

## References and Relevant Issues
Related to #4247

## Detailed Description of the Pull Request / Additional comments
- A single value like `--pos 500` now sets both `x` and `y` to `500`.
- A trailing comma (e.g., `--pos 500,`) sets only `x`, using the default for `y`.