### PR TITLE
Update uhfHeaderId to DevTools in docfx

### DIFF
--- a/TerminalDocs/docfx.json
+++ b/TerminalDocs/docfx.json
@@ -42,7 +42,7 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/windows/terminal/breadcrumb/toc.json",
-      "uhfHeaderId": "MSDocsHeader-Windows",
+      "uhfHeaderId": "MSDocsHeader-Windows-DevTools",
       "keywords": "Windows Terminal, terminal, windows shell, terminal docs",
       "feedback_product_url": "https://github.com/Microsoft/terminal/issues",
       "feedback_system": "OpenSource",


### PR DESCRIPTION
Updating the top menu to use the Windows Developer Tools menu instead of the generic Windows menu.