### PR TITLE
Replacing `OSC9;12` with `OCS133;A` as the one supported by Windows Terminal

### DIFF
--- a/TerminalDocs/tutorials/new-tab-same-directory.md
+++ b/TerminalDocs/tutorials/new-tab-same-directory.md
@@ -78,7 +78,7 @@ function prompt
 
   $prompt = & $GitPromptScriptBlock
 
-  $prompt += "$([char]27)]9;12$([char]7)"
+  $prompt += "$([char]27)]133;A$([char]7)"
   if ($loc.Provider.Name -eq "FileSystem")
   {
     $prompt += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
@@ -95,7 +95,7 @@ If you're using [Starship](http://starship.rs/), then that will already modify y
 ```powershell
 function Invoke-Starship-PreCommand {
   $loc = $executionContext.SessionState.Path.CurrentLocation;
-  $prompt = "$([char]27)]9;12$([char]7)"
+  $prompt = "$([char]27)]133;A$([char]7)"
   if ($loc.Provider.Name -eq "FileSystem")
   {
     $prompt += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"


### PR DESCRIPTION
VT sequence `OCS9;12` is supported by [ConEmu](https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC), but **not** supported by Windows Terminal. Windows Terminal supports `OCS133;A` (`FTCS_PROMPT`) to mark beginning of the prompt:
* [Windows Terminal - Shell Integration (Marks) / Supported VT sequences](https://github.com/microsoft/terminal/blob/main/doc/specs/%2311000%20-%20Marks/Shell-Integration-Marks.md#supported-vt-sequences)
* [Windows Terminal - Shell Integration / How does this work?](https://learn.microsoft.com/en-us/windows/terminal/tutorials/shell-integration#how-does-this-work)

As far as I know, in case of [Starship](https://starship.rs/advanced-config/#custom-pre-prompt-and-pre-execution-commands-in-cmd), there is not place to inject other sequences to properly mark all the parts of the prompt, i.e. `FTCS_COMMAND_START`, `FTCS_COMMAND_EXECUTED`, `FTCS_COMMAND_FINISHED`. And I'm not [posh-git](https://github.com/dahlbyk/posh-git) user.