### PR TITLE
Update useMica options for micaAlt and enum changes

### DIFF
--- a/TerminalDocs/customize-settings/themes.md
+++ b/TerminalDocs/customize-settings/themes.md
@@ -118,6 +118,9 @@ Note that when Mica is enabled for the window it is enabled under the entirety o
 > [!NOTE]
 > Mica is only available on Windows builds >= 22621.
 
+> [!IMPORTANT]
+> The `"micaAlt"` value is only available in [Windows Terminal Preview](https://aka.ms/terminal-preview).
+
 ### Window border
 
 This sets the color of the window border, when the window is active. When set to `null`, the border will use whatever the default color is for the OS theme.

--- a/TerminalDocs/customize-settings/themes.md
+++ b/TerminalDocs/customize-settings/themes.md
@@ -96,20 +96,24 @@ This enables the Mica effect on this window, beneath all other UI layers. For Mi
     "window":
     {
         "applicationTheme": "system",
-        "useMica": true
+        "useMica": "mica"
     }
 },
 ```
 
 Note that when Mica is enabled for the window it is enabled under the entirety of the window, including as a backdrop for the Terminal panes in the window. This means that profiles which are using `opacity` without `useAcrylic` enabled will show through to the new Mica background. It is not currently possible to have an unblurred transparent background for the Terminal and a Mica background for the tabs / tab row simultaneously.
 
+`"mica"` uses the standard Mica material. `"micaAlt"` uses the Mica Alt material, a variant of Mica with a stronger tint of the desktop wallpaper. `"none"` disables the backdrop.
+
+`true` and `false` are accepted as synonyms for `"mica"` and `"none"`, respectively.
+
 **Property name:** `useMica`
 
 **Necessity:** Optional
 
-**Accepts:** `true`, `false`
+**Accepts:** `"none"`, `"mica"`, `"micaAlt"`, `true`, `false`
 
-**Default value:** `false`
+**Default value:** `"none"`
 
 > [!NOTE]
 > Mica is only available on Windows builds >= 22621.


### PR DESCRIPTION
Updated the 'useMica' property options and default value in themes.md. Note that the change was done to mirror `closeOnExit` (https://github.com/MicrosoftDocs/terminal/pull/791) rather than `bellStyle` (https://github.com/MicrosoftDocs/terminal/commit/51f7cf01f97a <- direct commit) so synonyms are noted and legacy booleans are listed under accepted input types. 

`closeOnExit` is a similar boolean -> enum change and `bellStyle` is noted in the original issue as a relevant change. 

Corresponding code change: https://github.com/microsoft/terminal/pull/20464. Original issue: https://github.com/microsoft/terminal/issues/17650. 